### PR TITLE
limit number of entries allowed in objects

### DIFF
--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -9,12 +9,6 @@
 #include "src/convert.h"
 #include "src/log.h"
 
-/** TODO
-USE
-#define DDWAF_MAX_STRING_LENGTH 4096
-#define DDWAF_MAX_MAP_DEPTH 20
-#define DDWAF_MAX_ARRAY_LENGTH 256
-**/
 
 ddwaf_object* to_ddwaf_object_array(ddwaf_object *object, Napi::Env env,
                                               Napi::Array arr, int depth) {
@@ -46,7 +40,8 @@ ddwaf_object* to_ddwaf_object_array(ddwaf_object *object, Napi::Env env,
 ddwaf_object* to_ddwaf_object_object(ddwaf_object *object, Napi::Env env,
                                               Napi::Object obj, int depth) {
   Napi::Array properties = obj.GetPropertyNames();
-  uint32_t len = properties.Length();
+  uint32_t p_len = properties.Length();
+  uint32_t len = p_len > DDWAF_MAX_ARRAY_LENGTH ? DDWAF_MAX_ARRAY_LENGTH : p_len;
   if (env.IsExceptionPending()) {
     mlog("Exception pending");
     return nullptr;

--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -41,7 +41,8 @@ ddwaf_object* to_ddwaf_object_object(ddwaf_object *object, Napi::Env env,
                                               Napi::Object obj, int depth) {
   Napi::Array properties = obj.GetPropertyNames();
   uint32_t p_len = properties.Length();
-  uint32_t len = p_len > DDWAF_MAX_ARRAY_LENGTH ? DDWAF_MAX_ARRAY_LENGTH : p_len;
+  uint32_t len = p_len > DDWAF_MAX_ARRAY_LENGTH ?
+                                  DDWAF_MAX_ARRAY_LENGTH : p_len;
   if (env.IsExceptionPending()) {
     mlog("Exception pending");
     return nullptr;

--- a/test/index.js
+++ b/test/index.js
@@ -74,7 +74,7 @@ describe('limit tests', () => {
     }, 10000)
     assert.strictEqual(result0.action, 'monitor')
 
-    const item = {};
+    const item = {}
     for (let i = 0; i < 1000; ++i) {
       item[`a${i}`] = `${i}`
     }

--- a/test/index.js
+++ b/test/index.js
@@ -62,6 +62,31 @@ describe('DDWAF lifecycle', () => {
   })
 })
 
+describe('limit tests', () => {
+  it('should ignore elements too far in the objects', () => {
+    const waf = new DDWAF(rules)
+    const context = waf.createContext()
+
+    const result0 = context.run({
+      'server.response.status': {
+        a0: '404'
+      }
+    }, 10000)
+    assert.strictEqual(result0.action, 'monitor')
+
+    const item = {};
+    for (let i = 0; i < 1000; ++i) {
+      item[`a${i}`] = `${i}`
+    }
+
+    const result = context.run({
+      'server.response.status': item
+    }, 10000)
+    assert.strictEqual(result.action, undefined)
+    assert(!result.data)
+  })
+})
+
 describe('load tests', () => {
   // TODO: how to control memory impact of the addon
 })

--- a/test/rules.json
+++ b/test/rules.json
@@ -53,6 +53,33 @@
       "transformers": [
         "lowercase"
       ]
+    },
+    {
+      "id": "id2",
+      "name": "some name",
+      "tags": {
+        "type": "security_scanner",
+        "crs_id": "0",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.query"
+              }
+            ],
+            "list": [
+              "this is an attack"
+            ]
+          },
+          "operator": "phrase_match"
+        }
+      ],
+      "transformers": [
+        "lowercase"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Adding a limit to the number of properties per object. There is now a single biggest object allowed by the bindings
