### PR TITLE
Better manage the obfuscator config memory

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -56,6 +56,9 @@ DDWAF::DDWAF(const Napi::CallbackInfo& info) : Napi::ObjectWrap<DDWAF>(info) {
 
   ddwaf_config waf_config{{0, 0, 0}, {nullptr, nullptr}};
 
+  char* key_regex_str = nullptr;
+  char* value_regex_str = nullptr;
+
   if (arg_len >= 2) {
     // TODO(@simon-id) make a macro here someday
     if (!info[1].IsObject()) {
@@ -73,7 +76,8 @@ DDWAF::DDWAF(const Napi::CallbackInfo& info) : Napi::ObjectWrap<DDWAF>(info) {
         return;
       }
 
-      waf_config.obfuscator.key_regex = key_regex.ToString().Utf8Value().c_str();
+      key_regex_str = strdup(key_regex.ToString().Utf8Value().c_str());
+      waf_config.obfuscator.key_regex = key_regex_str;
     }
 
     if (config.Has("obfuscatorValueRegex")) {
@@ -84,7 +88,8 @@ DDWAF::DDWAF(const Napi::CallbackInfo& info) : Napi::ObjectWrap<DDWAF>(info) {
         return;
       }
 
-      waf_config.obfuscator.value_regex = value_regex.ToString().Utf8Value().c_str();
+      value_regex_str = strdup(value_regex.ToString().Utf8Value().c_str());
+      waf_config.obfuscator.value_regex = value_regex_str;
     }
   }
 
@@ -97,6 +102,9 @@ DDWAF::DDWAF(const Napi::CallbackInfo& info) : Napi::ObjectWrap<DDWAF>(info) {
   mlog("Init WAF");
   ddwaf_handle handle = ddwaf_init(&rules, &waf_config, &rules_info);
   ddwaf_object_free(&rules);
+
+  free(key_regex_str);
+  free(value_regex_str);
 
   Napi::Object result = Napi::Object::New(env);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,6 +19,7 @@ Napi::Object DDWAF::Init(Napi::Env env, Napi::Object exports) {
     InstanceMethod<&DDWAF::createContext>("createContext"),
     InstanceMethod<&DDWAF::dispose>("dispose"),
     InstanceAccessor("disposed", &DDWAF::GetDisposed, nullptr, napi_enumerable),
+    //InstanceValue("rulesInfo", Napi::Object::New(env), napi_enumerable),
     // TODO(simon-id): should we have an InstanceValue for rulesInfo here ?
   });
   exports.Set("DDWAF", func);
@@ -56,6 +57,7 @@ DDWAF::DDWAF(const Napi::CallbackInfo& info) : Napi::ObjectWrap<DDWAF>(info) {
 
   ddwaf_config waf_config{{0, 0, 0}, {nullptr, nullptr}};
 
+  // do not touch these strings after the c_str() assigment
   std::string key_regex_str;
   std::string value_regex_str;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,10 +6,10 @@
 #include <napi.h>
 #include <stdio.h>
 #include <ddwaf.h>
+#include <string>
 #include "src/main.h"
 #include "src/log.h"
 #include "src/convert.h"
-#include <string>
 
 Napi::FunctionReference* constructor = new Napi::FunctionReference();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,7 +19,6 @@ Napi::Object DDWAF::Init(Napi::Env env, Napi::Object exports) {
     InstanceMethod<&DDWAF::createContext>("createContext"),
     InstanceMethod<&DDWAF::dispose>("dispose"),
     InstanceAccessor("disposed", &DDWAF::GetDisposed, nullptr, napi_enumerable),
-    //InstanceValue("rulesInfo", Napi::Object::New(env), napi_enumerable),
     // TODO(simon-id): should we have an InstanceValue for rulesInfo here ?
   });
   exports.Set("DDWAF", func);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,6 +9,7 @@
 #include "src/main.h"
 #include "src/log.h"
 #include "src/convert.h"
+#include <string>
 
 Napi::FunctionReference* constructor = new Napi::FunctionReference();
 


### PR DESCRIPTION
### What does this PR do?

Better manage the memory of the obfuscator's strings.
