### PR TITLE
Replace `os.plateform()`  and `os.arch()`

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -3,11 +3,10 @@
  * This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
  **/
 'use strict'
-const os = require('os')
 const detectLibc = require('detect-libc')
 
 const getDir = module.exports.getDir = function () {
-  return `${os.platform()}-${os.arch()}-${detectLibc.family || 'unknown'}`
+  return `${process.platform}-${process.arch}-${detectLibc.family || 'unknown'}`
 }
 
 module.exports.load = function () {


### PR DESCRIPTION
Replace `os` methods by the cached `process` properties