### PR TITLE
Use `windows-2019` images in CI

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -23,11 +23,11 @@ jobs:
             artifact: darwin-x64-unknown
             arch: x64
           - name: windows 64 bits
-            os: windows-latest
+            os: windows-2019
             artifact: win32-x64-unknown
             arch: x64
           - name: windows 32 bits
-            os: windows-latest
+            os: windows-2019
             artifact: win32-ia32-unknown
             arch: x86
     runs-on: ${{ matrix.target.os }}
@@ -135,15 +135,15 @@ jobs:
             artifact: darwin-x64-unknown
             arch: x64
           - name: windows 64 bits
-            os: windows-latest
+            os: windows-2019
             artifact: win32-x64-unknown
             arch: x64
           - name: windows 32 bits
-            os: windows-latest
+            os: windows-2019
             artifact: win32-ia32-unknown
             arch: x86
           - name: windows 32 bits on 64 bits
-            os: windows-latest
+            os: windows-2019
             artifact: win32-ia32-unknown
             arch: x64
     runs-on: ${{ matrix.target.os }}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "licenses": "node scripts/check_licenses.js"
   },
   "repository": {
-    "type": "git", 
+    "type": "git",
     "url": "git+https://github.com/DataDog/dd-native-appsec-js.git"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "licenses": "node scripts/check_licenses.js"
   },
   "repository": {
-    "type": "git",
+    "type": "git", 
     "url": "git+https://github.com/DataDog/dd-native-appsec-js.git"
   },
   "keywords": [


### PR DESCRIPTION
### What does this PR do?

Hardcode the version of the windows image used in CI to `windows-2019`

### Motivation

`windows-latest` uses a version of msvc that seems incompatible with `libddwaf` builds.