### PR TITLE
Use codex-team/action-nodejs-package-info@v1.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/download-artifact@v3
       - run: npm pack
-      - uses: codex-team/action-nodejs-package-info@v1
+      - uses: codex-team/action-nodejs-package-info@v1.1
         id: package
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
### What does this PR do?

Use codex-team/action-nodejs-package-info@v1.1

### Motivation

The release workflow raised and error:

codex-team/action-nodejs-package-info@v1 is not allowed to be used in DataDog/dd-native-appsec-js. Actions in this workflow must be: within a repository that belongs to your Enterprise account, created by GitHub, verified in the GitHub Marketplace, or matching the following: codex-team/action-nodejs-package-info@v1.1.

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Describe how to test your changes

<!--
Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment
for testing, if the process requires more than just
running on one of the supported platforms.
-->

### Checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] The CHANGELOG.md has been updated
- [ ] Unit tests have been updated and pass
- [ ] If known, an appropriate milestone has been selected

