### PR TITLE
Version 4.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@datadog/native-appsec",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@datadog/native-appsec",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/native-appsec",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "Node.js bindings for libddwaf",
   "main": "index.js",
   "libddwaf_version": "1.14.0",


### PR DESCRIPTION
### What does this PR do?

Adds new version in order to release the suppport for the derivatives feature needed to API Security.


