### PR TITLE
Update waf version to 1.15.1

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -29,7 +29,7 @@ type result = {
 declare class DDWAFContext {
   readonly disposed: boolean;
 
-  run(inputs: object, ephemeral: object, timeout: number): result;
+  run(payload: object, timeout: number): result;
   dispose(): void;
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -29,7 +29,7 @@ type result = {
 declare class DDWAFContext {
   readonly disposed: boolean;
 
-  run(inputs: object, timeout: number): result;
+  run(inputs: object, ephemeral: object, timeout: number): result;
   dispose(): void;
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -24,12 +24,17 @@ type result = {
   status?: 'match'; // TODO: remove this if new statuses are never added
   actions?: string[];
   derivatives?: object;
-};
+}
+
+type payload = {
+  persistent?: object,
+  ephemeral?: object
+}
 
 declare class DDWAFContext {
   readonly disposed: boolean;
 
-  run(payload: object, timeout: number): result;
+  run(payload: payload, timeout: number): result;
   dispose(): void;
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -53,7 +53,7 @@ export class DDWAF {
     processors?: diagnosticsInfo
   };
 
-  readonly requiredAddresses: Set<string>;
+  readonly knownAddresses: Set<string>;
 
   constructor(rules: rules, config?: {
     obfuscatorKeyRegex?: string,

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,12 @@
  * This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
  **/
 type rules = object;
+
 type diagnosticsInfo = {
+  addresses: {
+    optional: string[],
+    required: string[]
+  },
   loaded: string[],
   failed: string[],
   error: string,

--- a/index.d.ts
+++ b/index.d.ts
@@ -49,7 +49,8 @@ export class DDWAF {
     custom_rules?: diagnosticsInfo,
     exclusions?: diagnosticsInfo,
     rules_override?: diagnosticsInfo,
-    rules_data?: diagnosticsInfo
+    rules_data?: diagnosticsInfo,
+    processors?: diagnosticsInfo
   };
 
   readonly requiredAddresses: Set<string>;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "5.0.0",
   "description": "Node.js bindings for libddwaf",
   "main": "index.js",
-  "libddwaf_version": "1.14.0",
+  "libddwaf_version": "1.15.1",
   "scripts": {
     "install": "exit 0",
     "rebuild": "node-gyp rebuild",

--- a/src/alloca.h
+++ b/src/alloca.h
@@ -1,0 +1,12 @@
+/**
+* Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+* This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
+**/
+#ifndef SRC_ALLOCA_H_
+  #define SRC_ALLOCA_H_
+  #ifdef _WIN32
+    #include <malloc.h>
+  #else
+    #include <alloca.h>
+  #endif
+#endif  // SRC_ALLOCA_H_

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -259,8 +259,9 @@ Napi::Value DDWAFContext::run(const Napi::CallbackInfo& info) {
     return env.Null();
   }
 
-  Napi::Value persistent = info[0].As<Napi::Object>().Get("persistent");
-  Napi::Value ephemeral = info[0].As<Napi::Object>().Get("ephemeral");
+  Napi::Object payload = info[0].As<Napi::Object>();
+  Napi::Value persistent = payload.Get("persistent");
+  Napi::Value ephemeral = payload.Get("ephemeral");
 
   if (!persistent.IsObject() && !ephemeral.IsObject()) {
     Napi::TypeError::New(env, "Persistent or ephemeral must be an object").ThrowAsJavaScriptException();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,7 +2,6 @@
 * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 * This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
 **/
-#include <alloca.h>
 #define NAPI_VERSION  4
 #include <napi.h>
 #include <stdio.h>
@@ -244,8 +243,8 @@ Napi::Value DDWAFContext::run(const Napi::CallbackInfo& info) {
     return env.Null();
   }
 
-  if (info.Length() < 2) {  // inputs, timeout
-    Napi::Error::New(env, "Wrong number of arguments, at least 2 expected").ThrowAsJavaScriptException();
+  if (info.Length() < 3) {  // inputs, timeout
+    Napi::Error::New(env, "Wrong number of arguments, 3 expected").ThrowAsJavaScriptException();
     return env.Null();
   }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -250,7 +250,10 @@ Napi::Value DDWAFContext::run(const Napi::CallbackInfo& info) {
   }
 
   if (!info[0].IsObject() && !info[1].IsObject()) {
-    Napi::TypeError::New(env, "One of persistent data or ephemeral data must be an object").ThrowAsJavaScriptException();
+    Napi::TypeError::New(
+            env,
+            "One of persistent data or ephemeral data must be an object")
+        .ThrowAsJavaScriptException();
     return env.Null();
   }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -112,7 +112,7 @@ DDWAF::DDWAF(const Napi::CallbackInfo& info) : Napi::ObjectWrap<DDWAF>(info) {
   this->_handle = handle;
   this->_disposed = false;
 
-  this->update_required_addresses(info);
+  this->update_known_addresses(info);
 }
 
 void DDWAF::Finalize(Napi::Env env) {
@@ -173,24 +173,24 @@ void DDWAF::update(const Napi::CallbackInfo& info) {
   ddwaf_destroy(this->_handle);
   this->_handle = updated_handle;
 
-  this->update_required_addresses(info);
+  this->update_known_addresses(info);
 }
 
-void DDWAF::update_required_addresses(const Napi::CallbackInfo& info) {
+void DDWAF::update_known_addresses(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
 
   uint32_t size = 0;
-  const char* const* required_addresses = ddwaf_known_addresses(this->_handle, &size);
+  const char* const* known_addresses = ddwaf_known_addresses(this->_handle, &size);
 
   Napi::Value set = env.RunScript("new Set()");
   Napi::Function set_add = set.As<Napi::Object>().Get("add").As<Napi::Function>();
 
   for (uint32_t i = 0; i < size; ++i) {
-    Napi::String address = Napi::String::New(env, required_addresses[i]);
+    Napi::String address = Napi::String::New(env, known_addresses[i]);
     set_add.Call(set, {address});
   }
 
-  info.This().As<Napi::Object>().Set("requiredAddresses", set);
+  info.This().As<Napi::Object>().Set("knownAddresses", set);
 }
 
 Napi::Value DDWAF::createContext(const Napi::CallbackInfo& info) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,11 +3,13 @@
 * This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
 **/
 #define NAPI_VERSION  4
-#include <malloc.h>
 #include <napi.h>
 #include <stdio.h>
 #include <ddwaf.h>
+
 #include <string>
+
+#include "src/alloca.h"
 #include "src/main.h"
 #include "src/log.h"
 #include "src/convert.h"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -268,14 +268,14 @@ Napi::Value DDWAFContext::run(const Napi::CallbackInfo& info) {
   ddwaf_object *data = nullptr;
 
   if (info[0].IsObject()) {
-    data = (ddwaf_object *) alloca(sizeof(ddwaf_object));
+    data = static_cast<ddwaf_object *>(alloca(sizeof(ddwaf_object)));
     to_ddwaf_object(data, env, info[0], 0, true);
   }
 
   ddwaf_object *ephemeral = nullptr;
 
   if (info[1].IsObject()) {
-    ephemeral = (ddwaf_object *) alloca(sizeof(ddwaf_object));
+    ephemeral = static_cast<ddwaf_object *>(alloca(sizeof(ddwaf_object)));
     to_ddwaf_object(ephemeral, env, info[1], 0, true);
   }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,7 @@
 * This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
 **/
 #define NAPI_VERSION  4
+#include <malloc.h>
 #include <napi.h>
 #include <stdio.h>
 #include <ddwaf.h>

--- a/src/main.h
+++ b/src/main.h
@@ -27,7 +27,7 @@ class DDWAF : public Napi::ObjectWrap<DDWAF> {
     void dispose(const Napi::CallbackInfo& info);
 
  private:
-    void update_required_addresses(const Napi::CallbackInfo& info);
+    void update_known_addresses(const Napi::CallbackInfo& info);
 
     bool _disposed;
     ddwaf_handle _handle;

--- a/test/fuzz.js
+++ b/test/fuzz.js
@@ -35,10 +35,10 @@ function test (buff, encoding = 'utf8') {
 
   const context = waf.createContext()
 
-  const r1 = context.run({ value_attack: str }, TIMEOUT)
+  const r1 = context.run({ value_attack: str }, null, TIMEOUT)
   assert(r1 && r1.events, `Expected to handle string value 0x${buff.toString('hex')} in ${encoding}`)
 
-  const r2 = context.run({ key_attack: { [str]: '' } }, TIMEOUT)
+  const r2 = context.run({ key_attack: { [str]: '' } }, null, TIMEOUT)
   assert(r2 && r2.events, `Expected to handle string key 0x${buff.toString('hex')} in ${encoding}`)
 
   context.dispose()

--- a/test/fuzz.js
+++ b/test/fuzz.js
@@ -32,13 +32,12 @@ const ENCODINGS = [ // from https://github.com/nodejs/node/blob/master/lib/buffe
 
 function test (buff, encoding = 'utf8') {
   const str = buff.toString(encoding)
-
   const context = waf.createContext()
 
-  const r1 = context.run({ value_attack: str }, null, TIMEOUT)
+  const r1 = context.run({ persistent: { value_attack: str } }, TIMEOUT)
   assert(r1 && r1.events, `Expected to handle string value 0x${buff.toString('hex')} in ${encoding}`)
 
-  const r2 = context.run({ key_attack: { [str]: '' } }, null, TIMEOUT)
+  const r2 = context.run({ persistent: { key_attack: { [str]: '' } } }, TIMEOUT)
   assert(r2 && r2.events, `Expected to handle string key 0x${buff.toString('hex')} in ${encoding}`)
 
   context.dispose()

--- a/test/index.js
+++ b/test/index.js
@@ -59,10 +59,10 @@ describe('DDWAF', () => {
     })
   })
 
-  it('should have requiredAddresses', () => {
+  it('should have knownAddresses', () => {
     const waf = new DDWAF(rules)
 
-    assert.deepStrictEqual(waf.requiredAddresses, new Set([
+    assert.deepStrictEqual(waf.knownAddresses, new Set([
       'http.client_ip',
       'server.request.headers.no_cookies',
       'server.response.status',
@@ -184,7 +184,7 @@ describe('DDWAF', () => {
       assert.throws(() => waf.update({}), new Error('WAF has not been updated'))
     })
 
-    it('should update diagnostics and requiredAddresses when updating a WAF instance with new ruleSet', () => {
+    it('should update diagnostics and knownAddresses when updating a WAF instance with new ruleSet', () => {
       const waf = new DDWAF({
         version: '2.2',
         metadata: {
@@ -227,7 +227,7 @@ describe('DDWAF', () => {
           errors: {}
         }
       })
-      assert.deepStrictEqual(waf.requiredAddresses, new Set([
+      assert.deepStrictEqual(waf.knownAddresses, new Set([
         'http.client_ip'
       ]))
 
@@ -267,7 +267,7 @@ describe('DDWAF', () => {
           }
         }
       })
-      assert.deepStrictEqual(waf.requiredAddresses, new Set([
+      assert.deepStrictEqual(waf.knownAddresses, new Set([
         'http.client_ip',
         'server.request.headers.no_cookies',
         'server.response.status',
@@ -454,15 +454,16 @@ describe('DDWAF', () => {
     const waf = new DDWAF(rules)
     const context = waf.createContext()
 
-    assert.throws(() => context.run(), new Error('Wrong number of arguments, 3 expected'))
+    const wronArgsError = new Error('Wrong number of arguments, 3 expected')
+    assert.throws(() => context.run(), wronArgsError)
 
-    let err = new TypeError('One of persistent data or ephemeral data must be an object')
-    assert.throws(() => context.run('', null, TIMEOUT), err)
-    assert.throws(() => context.run(null, '', TIMEOUT), err)
+    const objectError = new TypeError('One of persistent data or ephemeral data must be an object')
+    assert.throws(() => context.run('', null, TIMEOUT), objectError)
+    assert.throws(() => context.run(null, '', TIMEOUT), objectError)
 
-    err = new TypeError('Timeout argument must be greater than 0')
-    assert.throws(() => context.run({ 'server.request.headers.no_cookies': 'value_attack' }, null, -1), err)
-    assert.throws(() => context.run({ 'server.request.headers.no_cookies': 'value_attack' }, null, 0), err)
+    const greaterError = new TypeError('Timeout argument must be greater than 0')
+    assert.throws(() => context.run({ 'server.request.headers.no_cookies': 'value_attack' }, null, -1), greaterError)
+    assert.throws(() => context.run({ 'server.request.headers.no_cookies': 'value_attack' }, null, 0), greaterError)
   })
 
   it('should parse keys correctly', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -77,7 +77,10 @@ describe('DDWAF', () => {
     const context = waf.createContext()
     const payload = {
       persistent: {
-        'server.request.headers.no_cookies': 'value_ATTack'
+        'server.request.headers.no_cookies': 'value_ATTack',
+        x: new Array(4096).fill('x').join(''),
+        y: new Array(4097).fill('y').join(''),
+        z: new Array(4097).fill('z')
       }
     }
 

--- a/test/index.js
+++ b/test/index.js
@@ -116,8 +116,7 @@ describe('DDWAF', () => {
         'server.request.headers.no_cookies': 'value_ATTack'
       }
     },
-    TIMEOUT
-    )
+    TIMEOUT)
 
     assert.strictEqual(result.timeout, false)
     assert.strictEqual(result.status, 'match')
@@ -129,8 +128,7 @@ describe('DDWAF', () => {
         'server.request.headers.no_cookies': 'other_attack'
       }
     },
-    TIMEOUT
-    )
+    TIMEOUT)
 
     assert.strictEqual(result.timeout, false)
     assert.strictEqual(result.status, 'match')
@@ -420,8 +418,7 @@ describe('DDWAF', () => {
         'server.response.status': '404'
       }
     },
-    TIMEOUT
-    )
+    TIMEOUT)
 
     assert.strictEqual(result.status, 'match')
     assert(result.events)

--- a/test/index.js
+++ b/test/index.js
@@ -9,6 +9,7 @@ const { DDWAF } = require('..')
 const pkg = require('../package.json')
 const rules = require('./rules.json')
 const processor = require('./processor.json')
+const {json} = require('express')
 
 const TIMEOUT = 9999e3
 
@@ -589,8 +590,11 @@ describe('DDWAF', () => {
     assert.strictEqual(result.events[0].rule_matches[0].parameters[0].highlight[0], '<Redacted>')
   })
 
-  it('should collect derivatives information when a rule match', () => {
+  it.only('should collect derivatives information when a rule match', () => {
+    console.log('Rules: ', JSON.stringify(processor))
     const waf = new DDWAF(processor)
+    console.log('Diagnostics:', JSON.stringify(waf.diagnostics))
+
     const context = waf.createContext()
 
     assert.deepStrictEqual(

--- a/test/index.js
+++ b/test/index.js
@@ -624,23 +624,11 @@ describe('DDWAF', () => {
     const waf = new DDWAF(processor)
     const context = waf.createContext()
 
-    assert.deepStrictEqual(
-      waf.diagnostics.processors,
-      {
-        addresses: {
-          optional: [
-            'server.request.query',
-            'server.request.body'
-          ],
-          required: [
-            'waf.context.processor'
-          ]
-        },
-        loaded: ['processor-001'],
-        failed: [],
-        errors: {}
-      }
-    )
+    assert(waf.diagnostics.processors.addresses.optional.includes('server.request.query'))
+    assert(waf.diagnostics.processors.addresses.optional.includes('server.request.body'))
+    assert(waf.diagnostics.processors.addresses.required.includes('waf.context.processor'))
+    assert(waf.diagnostics.processors.loaded.includes('processor-001'))
+    assert.equal(waf.diagnostics.processors.failed.length, 0)
 
     const result = context.run({
       persistent: {
@@ -665,23 +653,11 @@ describe('DDWAF', () => {
     const waf = new DDWAF(processor)
     const context = waf.createContext()
 
-    assert.deepStrictEqual(
-      waf.diagnostics.processors,
-      {
-        addresses: {
-          optional: [
-            'server.request.query',
-            'server.request.body'
-          ],
-          required: [
-            'waf.context.processor'
-          ]
-        },
-        loaded: ['processor-001'],
-        failed: [],
-        errors: {}
-      }
-    )
+    assert(waf.diagnostics.processors.addresses.optional.includes('server.request.query'))
+    assert(waf.diagnostics.processors.addresses.optional.includes('server.request.body'))
+    assert(waf.diagnostics.processors.addresses.required.includes('waf.context.processor'))
+    assert(waf.diagnostics.processors.loaded.includes('processor-001'))
+    assert.equal(waf.diagnostics.processors.failed.length, 0)
 
     const result = context.run({
       persistent: {
@@ -740,23 +716,11 @@ describe('DDWAF', () => {
     const waf = new DDWAF(processor)
     const context = waf.createContext()
 
-    assert.deepStrictEqual(
-      waf.diagnostics.processors,
-      {
-        addresses: {
-          optional: [
-            'server.request.query',
-            'server.request.body'
-          ],
-          required: [
-            'waf.context.processor'
-          ]
-        },
-        loaded: ['processor-001'],
-        failed: [],
-        errors: {}
-      }
-    )
+    assert(waf.diagnostics.processors.addresses.optional.includes('server.request.query'))
+    assert(waf.diagnostics.processors.addresses.optional.includes('server.request.body'))
+    assert(waf.diagnostics.processors.addresses.required.includes('waf.context.processor'))
+    assert(waf.diagnostics.processors.loaded.includes('processor-001'))
+    assert.equal(waf.diagnostics.processors.failed.length, 0)
 
     let result = context.run({
       persistent: {

--- a/test/index.js
+++ b/test/index.js
@@ -9,7 +9,6 @@ const { DDWAF } = require('..')
 const pkg = require('../package.json')
 const rules = require('./rules.json')
 const processor = require('./processor.json')
-const {json} = require('express')
 
 const TIMEOUT = 9999e3
 

--- a/test/index.js
+++ b/test/index.js
@@ -589,30 +589,16 @@ describe('DDWAF', () => {
     assert.strictEqual(result.events[0].rule_matches[0].parameters[0].highlight[0], '<Redacted>')
   })
 
-  it.only('should collect derivatives information when a rule match', () => {
-    console.log('Rules: ', JSON.stringify(processor))
+  it('should collect derivatives information when a rule match', () => {
     const waf = new DDWAF(processor)
-    console.log('Diagnostics:', JSON.stringify(waf.diagnostics))
 
     const context = waf.createContext()
 
-    assert.deepStrictEqual(
-      waf.diagnostics.processors,
-      {
-        addresses: {
-          optional: [
-            'server.request.query',
-            'server.request.body'
-          ],
-          required: [
-            'waf.context.processor'
-          ]
-        },
-        loaded: ['processor-001'],
-        failed: [],
-        errors: {}
-      }
-    )
+    assert(waf.diagnostics.processors.addresses.optional.includes('server.request.query'))
+    assert(waf.diagnostics.processors.addresses.optional.includes('server.request.body'))
+    assert(waf.diagnostics.processors.addresses.required.includes('waf.context.processor'))
+    assert(waf.diagnostics.processors.loaded.includes('processor-001'))
+    assert.equal(waf.diagnostics.processors.failed.length, 0)
 
     const result = context.run({
       persistent: {

--- a/test/rules.json
+++ b/test/rules.json
@@ -42,7 +42,8 @@
               }
             ],
             "list": [
-              "value_attack"
+              "value_attack",
+              "other_attack"
             ]
           },
           "operator": "phrase_match"


### PR DESCRIPTION
### What does this PR do?

This PR updates the libddwaf version to 1.15.1. It contains breaking API changes:
* Add a new parameter to handle the whole payload: persistent and ephemeral addresses.
* Change function 'ddwaf_required_addresses' to 'ddwaf_known_addresses'.


[APPSEC-12207]



[APPSEC-12283]: https://datadoghq.atlassian.net/browse/APPSEC-12207

[APPSEC-12207]: https://datadoghq.atlassian.net/browse/APPSEC-12207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ