### PR TITLE
v7.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@datadog/native-appsec",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@datadog/native-appsec",
-      "version": "6.0.0",
+      "version": "7.0.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -24,7 +24,7 @@
         "tar": "^6.1.11"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/native-appsec",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "description": "Node.js bindings for libddwaf",
   "main": "index.js",
   "libddwaf_version": "1.15.1",


### PR DESCRIPTION
### What does this PR do?

Update package version to v7.0.0

### Motivation

Release new major version not compatible with node 12 and with worker_threads support

