### PR TITLE
use toJSON() property when it exists

### DIFF
--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -13,16 +13,6 @@
 #include "src/convert.h"
 #include "src/log.h"
 
-
-ddwaf_object* to_ddwaf_object(
-        ddwaf_object *object,
-        Napi::Env env,
-        Napi::Value val,
-        int depth,
-        bool lim,
-        bool ignoreToJson
-);
-
 ddwaf_object* to_ddwaf_object_array(
   ddwaf_object *object,
   Napi::Env env,
@@ -125,15 +115,7 @@ ddwaf_object* to_ddwaf_string(ddwaf_object *object, Napi::Value val, bool lim) {
   }
   return ddwaf_object_stringl(object, str.c_str(), len);
 }
-ddwaf_object* to_ddwaf_object(
-        ddwaf_object *object,
-        Napi::Env env,
-        Napi::Value val,
-        int depth,
-        bool lim
-) {
-  return to_ddwaf_object(object, env, val, depth, lim, false);
-}
+
 ddwaf_object* to_ddwaf_object(
   ddwaf_object *object,
   Napi::Env env,

--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -14,14 +14,30 @@
 #include "src/log.h"
 
 
+ddwaf_object* to_ddwaf_object(
+        ddwaf_object *object,
+        Napi::Env env,
+        Napi::Value val,
+        int depth,
+        bool lim,
+        bool ignoreToJson
+);
 
 ddwaf_object* to_ddwaf_object_array(
   ddwaf_object *object,
   Napi::Env env,
   Napi::Array arr,
   int depth,
-  bool lim
+  bool lim,
+  bool ignoreToJSON
 ) {
+  if (!ignoreToJSON) {
+      Napi::Value toJSON = arr.Get("toJSON");
+      if (toJSON.IsFunction()) {
+        return to_ddwaf_object(object, env, toJSON.As<Napi::Function>().Call(arr, {}), depth, lim, true);
+      }
+  }
+
   uint32_t len = arr.Length();
   if (env.IsExceptionPending()) {
     mlog("Exception pending");
@@ -54,12 +70,14 @@ ddwaf_object* to_ddwaf_object_object(
   Napi::Env env,
   Napi::Object obj,
   int depth,
-  bool lim
+  bool lim,
+  bool ignoreToJSON
 ) {
-  Napi::Value toJSON = obj.Get("toJSON");
-  if (toJSON.IsFunction()) {
-    Napi::Value json = toJSON.As<Napi::Function>().Call(obj, {});
-    obj = json.ToObject();
+  if (!ignoreToJSON) {
+    Napi::Value toJSON = obj.Get("toJSON");
+    if (toJSON.IsFunction()) {
+      return to_ddwaf_object(object, env, toJSON.As<Napi::Function>().Call(obj, {}), depth, lim, true);
+    }
   }
 
   Napi::Array properties = obj.GetPropertyNames();
@@ -107,13 +125,22 @@ ddwaf_object* to_ddwaf_string(ddwaf_object *object, Napi::Value val, bool lim) {
   }
   return ddwaf_object_stringl(object, str.c_str(), len);
 }
-
+ddwaf_object* to_ddwaf_object(
+        ddwaf_object *object,
+        Napi::Env env,
+        Napi::Value val,
+        int depth,
+        bool lim
+) {
+  return to_ddwaf_object(object, env, val, depth, lim, false);
+}
 ddwaf_object* to_ddwaf_object(
   ddwaf_object *object,
   Napi::Env env,
   Napi::Value val,
   int depth,
-  bool lim
+  bool lim,
+  bool ignoreToJson
 ) {
   mlog("starting to convert an object");
   if (depth >= DDWAF_MAX_CONTAINER_DEPTH) {
@@ -154,7 +181,7 @@ ddwaf_object* to_ddwaf_object(
   }
   if (val.IsArray()) {
     mlog("creating Array");
-    return to_ddwaf_object_array(object, env, val.ToObject().As<Napi::Array>(), depth + 1, lim);
+    return to_ddwaf_object_array(object, env, val.ToObject().As<Napi::Array>(), depth + 1, lim, ignoreToJson);
   }
   if (val.IsFunction()) {
     // Special case because a function will evaluate true for both IsFunction and IsObject.
@@ -162,7 +189,7 @@ ddwaf_object* to_ddwaf_object(
   }
   if (val.IsObject()) {
     mlog("creating Object");
-    return to_ddwaf_object_object(object, env, val.ToObject(), depth + 1, lim);
+    return to_ddwaf_object_object(object, env, val.ToObject(), depth + 1, lim, ignoreToJson);
   }
   mlog("creating invalid object");
   return ddwaf_object_invalid(object);

--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -56,6 +56,12 @@ ddwaf_object* to_ddwaf_object_object(
   int depth,
   bool lim
 ) {
+  Napi::Value toJSON = obj.Get("toJSON");
+  if (toJSON.IsFunction()) {
+    Napi::Value json = toJSON.As<Napi::Function>().Call({});
+    obj = json.ToObject();
+  }
+
   Napi::Array properties = obj.GetPropertyNames();
   uint32_t len = properties.Length();
   if (lim && len > DDWAF_MAX_CONTAINER_SIZE) {

--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -58,7 +58,7 @@ ddwaf_object* to_ddwaf_object_object(
 ) {
   Napi::Value toJSON = obj.Get("toJSON");
   if (toJSON.IsFunction()) {
-    Napi::Value json = toJSON.As<Napi::Function>().Call({});
+    Napi::Value json = toJSON.As<Napi::Function>().Call(obj, {});
     obj = json.ToObject();
   }
 

--- a/src/convert.h
+++ b/src/convert.h
@@ -13,7 +13,8 @@ ddwaf_object* to_ddwaf_object(
   Napi::Env env,
   Napi::Value val,
   int depth,
-  bool lim
+  bool lim,
+  bool ignoreToJson = false
 );
 
 Napi::Value from_ddwaf_object(ddwaf_object *object, Napi::Env env, int depth = 0);

--- a/test/index.js
+++ b/test/index.js
@@ -832,6 +832,7 @@ describe('limit tests', () => {
 
     const body = { a: 'not_an_attack' }
 
+    // should not match
     const context1 = waf.createContext()
     const result1 = context1.run({
       persistent: {
@@ -845,7 +846,7 @@ describe('limit tests', () => {
       return { a: '.htaccess' }
     }
 
-    // test last item in big rule
+    // should match
     const context2 = waf.createContext()
     const result2 = context2.run({
       persistent: {

--- a/test/index.js
+++ b/test/index.js
@@ -860,7 +860,7 @@ describe('limit tests', () => {
   it('should use custom toJSON function in arrays', () => {
     const waf = new DDWAF(rules)
 
-    const body = [{ a: 'not_an_attack' }]
+    const body = ['not_an_attack']
 
     // should not match
     const context1 = waf.createContext()
@@ -873,7 +873,7 @@ describe('limit tests', () => {
 
     body.toJSON = function toJSON () {
       assert(this === body)
-      return [{ a: '.htaccess' }]
+      return ['.htaccess']
     }
 
     // should match

--- a/test/index.js
+++ b/test/index.js
@@ -913,6 +913,7 @@ describe('limit tests', () => {
         }
       }
     }, TIMEOUT)
+
     assert.deepStrictEqual(result.derivatives, {
       'server.request.body.schema': [
         [
@@ -961,6 +962,52 @@ describe('limit tests', () => {
         {
           c: [8],
           toJSON: [0]
+        }
+      ]
+    })
+  })
+
+  it('should call toJSON functions on children properties', () => {
+    const body = {
+      a: 1,
+      b: {
+        b: 2,
+        toJSON: function () {
+          return { b: 'b-OK' }
+        }
+      },
+      c: {
+        c: 3,
+        toJSON: function () {
+          return { c: 'c-OK' }
+        }
+      },
+      toJSON: function () {
+        return {
+          a: this.a,
+          b: this.b,
+          c: this.c
+        }
+      }
+    }
+
+    const waf = new DDWAF(processor)
+    const context = waf.createContext()
+    const result = context.run({
+      persistent: {
+        'server.request.body': body,
+        'waf.context.processor': {
+          'extract-schema': true
+        }
+      }
+    }, TIMEOUT)
+
+    assert.deepStrictEqual(result.derivatives, {
+      'server.request.body.schema': [
+        {
+          a: [16],
+          b: [{ b: [8] }],
+          c: [{ c: [8] }]
         }
       ]
     })

--- a/test/index.js
+++ b/test/index.js
@@ -840,7 +840,10 @@ describe('limit tests', () => {
     }, TIMEOUT)
     assert(!result1.status)
 
-    body.toJSON = () => ({ a: '.htaccess' })
+    body.toJSON = function toJSON () {
+      assert(this === body)
+      return { a: '.htaccess' }
+    }
 
     // test last item in big rule
     const context2 = waf.createContext()

--- a/test/index.js
+++ b/test/index.js
@@ -115,8 +115,7 @@ describe('DDWAF', () => {
       ephemeral: {
         'server.request.headers.no_cookies': 'value_ATTack'
       }
-    },
-    TIMEOUT)
+    }, TIMEOUT)
 
     assert.strictEqual(result.timeout, false)
     assert.strictEqual(result.status, 'match')
@@ -127,8 +126,7 @@ describe('DDWAF', () => {
       ephemeral: {
         'server.request.headers.no_cookies': 'other_attack'
       }
-    },
-    TIMEOUT)
+    }, TIMEOUT)
 
     assert.strictEqual(result.timeout, false)
     assert.strictEqual(result.status, 'match')
@@ -417,8 +415,7 @@ describe('DDWAF', () => {
       persistent: {
         'server.response.status': '404'
       }
-    },
-    TIMEOUT)
+    }, TIMEOUT)
 
     assert.strictEqual(result.status, 'match')
     assert(result.events)
@@ -453,14 +450,12 @@ describe('DDWAF', () => {
       persistent: {
         'server.request.headers.no_cookies': 'value_attack'
       }
-    }, -1),
-    greaterError)
+    }, -1), greaterError)
     assert.throws(() => context.run({
       persistent: {
         'server.request.headers.no_cookies': 'value_attack'
       }
-    }, 0),
-    greaterError)
+    }, 0), greaterError)
   })
 
   it('should parse keys correctly', () => {
@@ -493,8 +488,7 @@ describe('DDWAF', () => {
             [key]: 'value'
           }
         }
-      },
-      TIMEOUT)
+      }, TIMEOUT)
 
       assert.strictEqual(result.status, 'match')
       assert(result.events)
@@ -532,8 +526,7 @@ describe('DDWAF', () => {
             key: value
           }
         }
-      },
-      TIMEOUT)
+      }, TIMEOUT)
 
       assert.strictEqual(result.timeout, false)
 
@@ -559,8 +552,7 @@ describe('DDWAF', () => {
           }
         }
       }
-    },
-    TIMEOUT)
+    }, TIMEOUT)
 
     assert(result)
     assert(result.events)
@@ -580,8 +572,7 @@ describe('DDWAF', () => {
           header: 'value_attack'
         }
       }
-    },
-    TIMEOUT)
+    }, TIMEOUT)
 
     assert(result)
     assert(result.events)
@@ -607,8 +598,7 @@ describe('DDWAF', () => {
           'extract-schema': true
         }
       }
-    },
-    TIMEOUT)
+    }, TIMEOUT)
 
     assert.strictEqual(result.status, 'match')
     assert.deepStrictEqual(result.derivatives, { 'server.request.body.schema': [8] })
@@ -637,8 +627,7 @@ describe('DDWAF', () => {
           'extract-schema': true
         }
       }
-    },
-    TIMEOUT)
+    }, TIMEOUT)
 
     assert.deepStrictEqual(result.derivatives, { 'server.request.body.schema': [8] })
 
@@ -681,8 +670,7 @@ describe('DDWAF', () => {
           'extract-schema': true
         }
       }
-    },
-    TIMEOUT)
+    }, TIMEOUT)
 
     assert.deepStrictEqual(result.derivatives, {
       'server.request.body.schema': [
@@ -726,8 +714,7 @@ describe('DDWAF', () => {
       persistent: {
         'server.request.body': ''
       }
-    },
-    TIMEOUT)
+    }, TIMEOUT)
 
     assert.strictEqual(result.derivatives, undefined)
 
@@ -738,8 +725,7 @@ describe('DDWAF', () => {
           'extract-schema': true
         }
       }
-    },
-    TIMEOUT)
+    }, TIMEOUT)
 
     assert.deepStrictEqual(result.derivatives, { 'server.request.body.schema': [8] })
 
@@ -747,8 +733,7 @@ describe('DDWAF', () => {
       persistent: {
         'server.request.query': ''
       }
-    },
-    TIMEOUT)
+    }, TIMEOUT)
 
     assert.deepStrictEqual(result.derivatives, { 'server.request.query.schema': [8] })
 
@@ -771,8 +756,7 @@ describe('limit tests', () => {
           a0: '404'
         }
       }
-    },
-    TIMEOUT)
+    }, TIMEOUT)
     assert.strictEqual(result1.status, 'match')
     assert(result1.events)
 
@@ -786,8 +770,7 @@ describe('limit tests', () => {
       persistent: {
         'server.response.status': item
       }
-    },
-    TIMEOUT)
+    }, TIMEOUT)
     assert(!result2.status)
     assert(!result2.events)
   })
@@ -800,8 +783,7 @@ describe('limit tests', () => {
       persistent: {
         'server.request.headers.no_cookies': createNestedObject(5, { header: 'value_attack' })
       }
-    },
-    TIMEOUT)
+    }, TIMEOUT)
 
     assert.strictEqual(result.status, 'match')
     assert(result.events)
@@ -815,8 +797,7 @@ describe('limit tests', () => {
       persistent: {
         'server.request.headers.no_cookies': createNestedObject(100, { header: 'value_attack' })
       }
-    },
-    TIMEOUT)
+    }, TIMEOUT)
 
     assert(!result.status)
     assert(!result.events)
@@ -831,8 +812,7 @@ describe('limit tests', () => {
       persistent: {
         'server.request.body': { a: '.htaccess' }
       }
-    },
-    TIMEOUT)
+    }, TIMEOUT)
     assert(result1.status)
     assert(result1.events)
 
@@ -842,8 +822,33 @@ describe('limit tests', () => {
       persistent: {
         'server.request.body': { a: 'yarn.lock' }
       }
-    },
-    TIMEOUT)
+    }, TIMEOUT)
+    assert(result2.status)
+    assert(result2.events)
+  })
+
+  it('should use custom toJSON function', () => {
+    const waf = new DDWAF(rules)
+
+    const body = { a: 'not_an_attack' }
+
+    const context1 = waf.createContext()
+    const result1 = context1.run({
+      persistent: {
+        'server.request.body': body
+      }
+    }, TIMEOUT)
+    assert(!result1.status)
+
+    body.toJSON = () => ({ a: '.htaccess' })
+
+    // test last item in big rule
+    const context2 = waf.createContext()
+    const result2 = context2.run({
+      persistent: {
+        'server.request.body': body
+      }
+    }, TIMEOUT)
     assert(result2.status)
     assert(result2.events)
   })


### PR DESCRIPTION
### What does this PR do?

When converting objects and arrays, if the `toJSON()` method is present, call it and use it as result

