### PR TITLE
Prevent circular dependencies

### DIFF
--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -34,10 +34,10 @@ ddwaf_object* to_ddwaf_object_array(
   JsSet jsSet
 ) {
   if (!ignoreToJSON) {
-      Napi::Value toJSON = arr.Get("toJSON");
-      if (toJSON.IsFunction()) {
-        return to_ddwaf_object(object, env, toJSON.As<Napi::Function>().Call(arr, {}), depth, lim, true, jsSet);
-      }
+    Napi::Value toJSON = arr.Get("toJSON");
+    if (toJSON.IsFunction()) {
+      return to_ddwaf_object(object, env, toJSON.As<Napi::Function>().Call(arr, {}), depth, lim, true, jsSet);
+    }
   }
 
   uint32_t len = arr.Length();
@@ -79,52 +79,52 @@ ddwaf_object* to_ddwaf_object_object(
   if (!ignoreToJSON) {
     Napi::Value toJSON = obj.Get("toJSON");
     if (toJSON.IsFunction()) {
-        return to_ddwaf_object(object, env, toJSON.As<Napi::Function>().Call(obj, {}), depth, lim, true, jsSet);
+      return to_ddwaf_object(object, env, toJSON.As<Napi::Function>().Call(obj, {}), depth, lim, true, jsSet);
     }
   }
 
   if (jsSet.Has(obj)) {
-      mlog("Circular dependency")
-      return ddwaf_object_invalid(object);
+    mlog("Circular dependency")
+    return ddwaf_object_invalid(object);
   } else {
-      jsSet.Add(obj);
-      Napi::Array properties = obj.GetPropertyNames();
-      uint32_t len = properties.Length();
-      if (lim && len > DDWAF_MAX_CONTAINER_SIZE) {
-          len = DDWAF_MAX_CONTAINER_SIZE;
-      }
-      if (env.IsExceptionPending()) {
-          mlog("Exception pending");
-          jsSet.Delete(obj);
-          return nullptr;
-      }
-
-      ddwaf_object *map = ddwaf_object_map(object);
-      if (map == nullptr) {
-          mlog("failed to create map");
-          jsSet.Delete(obj);
-          return nullptr;
-      }
-
-      for (uint32_t i = 0; i < len; ++i) {
-          mlog("Getting properties");
-          Napi::Value keyV = properties.Get(i);
-          if (!obj.HasOwnProperty(keyV) || !keyV.IsString()) {
-              // We avoid inherited properties here.
-              // If the key is not a String, well this is weird
-              continue;
-          }
-          std::string key = keyV.ToString().Utf8Value();
-          Napi::Value valV = obj.Get(keyV);
-          mlog("Looping into ToPWArgs");
-          ddwaf_object val;
-          to_ddwaf_object(&val, env, valV, depth, lim, false, jsSet);
-          if (!ddwaf_object_map_add(map, key.c_str(), &val)) {
-              mlog("add to object failed, freeing");
-              ddwaf_object_free(&val);
-          }
-      }
+    jsSet.Add(obj);
+    Napi::Array properties = obj.GetPropertyNames();
+    uint32_t len = properties.Length();
+    if (lim && len > DDWAF_MAX_CONTAINER_SIZE) {
+      len = DDWAF_MAX_CONTAINER_SIZE;
+    }
+    if (env.IsExceptionPending()) {
+      mlog("Exception pending");
       jsSet.Delete(obj);
+      return nullptr;
+    }
+
+    ddwaf_object *map = ddwaf_object_map(object);
+    if (map == nullptr) {
+      mlog("failed to create map");
+      jsSet.Delete(obj);
+      return nullptr;
+    }
+
+    for (uint32_t i = 0; i < len; ++i) {
+      mlog("Getting properties");
+      Napi::Value keyV = properties.Get(i);
+      if (!obj.HasOwnProperty(keyV) || !keyV.IsString()) {
+        // We avoid inherited properties here.
+        // If the key is not a String, well this is weird
+        continue;
+      }
+      std::string key = keyV.ToString().Utf8Value();
+      Napi::Value valV = obj.Get(keyV);
+      mlog("Looping into ToPWArgs");
+      ddwaf_object val;
+      to_ddwaf_object(&val, env, valV, depth, lim, false, jsSet);
+      if (!ddwaf_object_map_add(map, key.c_str(), &val)) {
+        mlog("add to object failed, freeing");
+        ddwaf_object_free(&val);
+      }
+    }
+    jsSet.Delete(obj);
   }
   return object;
 }
@@ -201,14 +201,14 @@ ddwaf_object* to_ddwaf_object(
 }
 
 ddwaf_object* to_ddwaf_object(
-        ddwaf_object *object,
-        Napi::Env env,
-        Napi::Value val,
-        int depth,
-        bool lim,
-        bool ignoreToJson
+  ddwaf_object *object,
+  Napi::Env env,
+  Napi::Value val,
+  int depth,
+  bool lim,
+  bool ignoreToJson
 ) {
-    return to_ddwaf_object(object, env, val, depth, lim, ignoreToJson, JsSet::Create(env));
+  return to_ddwaf_object(object, env, val, depth, lim, ignoreToJson, JsSet::Create(env));
 }
 
 Napi::Value from_ddwaf_object(ddwaf_object *object, Napi::Env env, int depth) {

--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -200,6 +200,7 @@ ddwaf_object* to_ddwaf_object(
     jsSet.Delete(val);
     return result;
   }
+  jsSet.Delete(val);
   mlog("creating invalid object");
   return ddwaf_object_invalid(object);
 }

--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -86,46 +86,47 @@ ddwaf_object* to_ddwaf_object_object(
   if (jsSet.Has(obj)) {
     mlog("Circular dependency")
     return ddwaf_object_invalid(object);
-  } else {
-    jsSet.Add(obj);
-    Napi::Array properties = obj.GetPropertyNames();
-    uint32_t len = properties.Length();
-    if (lim && len > DDWAF_MAX_CONTAINER_SIZE) {
-      len = DDWAF_MAX_CONTAINER_SIZE;
-    }
-    if (env.IsExceptionPending()) {
-      mlog("Exception pending");
-      jsSet.Delete(obj);
-      return nullptr;
-    }
-
-    ddwaf_object *map = ddwaf_object_map(object);
-    if (map == nullptr) {
-      mlog("failed to create map");
-      jsSet.Delete(obj);
-      return nullptr;
-    }
-
-    for (uint32_t i = 0; i < len; ++i) {
-      mlog("Getting properties");
-      Napi::Value keyV = properties.Get(i);
-      if (!obj.HasOwnProperty(keyV) || !keyV.IsString()) {
-        // We avoid inherited properties here.
-        // If the key is not a String, well this is weird
-        continue;
-      }
-      std::string key = keyV.ToString().Utf8Value();
-      Napi::Value valV = obj.Get(keyV);
-      mlog("Looping into ToPWArgs");
-      ddwaf_object val;
-      to_ddwaf_object(&val, env, valV, depth, lim, false, jsSet);
-      if (!ddwaf_object_map_add(map, key.c_str(), &val)) {
-        mlog("add to object failed, freeing");
-        ddwaf_object_free(&val);
-      }
-    }
-    jsSet.Delete(obj);
   }
+
+  jsSet.Add(obj);
+  Napi::Array properties = obj.GetPropertyNames();
+  uint32_t len = properties.Length();
+  if (lim && len > DDWAF_MAX_CONTAINER_SIZE) {
+    len = DDWAF_MAX_CONTAINER_SIZE;
+  }
+  if (env.IsExceptionPending()) {
+    mlog("Exception pending");
+    jsSet.Delete(obj);
+    return nullptr;
+  }
+
+  ddwaf_object *map = ddwaf_object_map(object);
+  if (map == nullptr) {
+    mlog("failed to create map");
+    jsSet.Delete(obj);
+    return nullptr;
+  }
+
+  for (uint32_t i = 0; i < len; ++i) {
+    mlog("Getting properties");
+    Napi::Value keyV = properties.Get(i);
+    if (!obj.HasOwnProperty(keyV) || !keyV.IsString()) {
+      // We avoid inherited properties here.
+      // If the key is not a String, well this is weird
+      continue;
+    }
+    std::string key = keyV.ToString().Utf8Value();
+    Napi::Value valV = obj.Get(keyV);
+    mlog("Looping into ToPWArgs");
+    ddwaf_object val;
+    to_ddwaf_object(&val, env, valV, depth, lim, false, jsSet);
+    if (!ddwaf_object_map_add(map, key.c_str(), &val)) {
+      mlog("add to object failed, freeing");
+      ddwaf_object_free(&val);
+    }
+  }
+  jsSet.Delete(obj);
+
   return object;
 }
 

--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -189,7 +189,8 @@ ddwaf_object* to_ddwaf_object(
 
   if (val.IsArray()) {
     mlog("creating Array");
-    auto result = to_ddwaf_object_array(object, env, val.ToObject().As<Napi::Array>(), depth + 1, lim, ignoreToJson, jsSet);
+    auto result =
+      to_ddwaf_object_array(object, env, val.ToObject().As<Napi::Array>(), depth + 1, lim, ignoreToJson, jsSet);
     jsSet.Delete(val);
     return result;
   }

--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -100,7 +100,7 @@ ddwaf_object* to_ddwaf_object_object(
     return nullptr;
   }
 
-  ddwaf_object *map = ddwaf_object_map(object);
+  ddwaf_object* map = ddwaf_object_map(object);
   if (map == nullptr) {
     mlog("failed to create map");
     jsSet.Delete(obj);

--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -15,13 +15,13 @@
 #include "src/jsset.h"
 
 ddwaf_object* to_ddwaf_object(
-        ddwaf_object *object,
-        Napi::Env env,
-        Napi::Value val,
-        int depth,
-        bool lim,
-        bool ignoreToJSON,
-        JsSet jsSet
+  ddwaf_object *object,
+  Napi::Env env,
+  Napi::Value val,
+  int depth,
+  bool lim,
+  bool ignoreToJSON,
+  JsSet jsSet
 );
 
 ddwaf_object* to_ddwaf_object_array(

--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -87,8 +87,8 @@ ddwaf_object* to_ddwaf_object_object(
     mlog("Circular dependency")
     return ddwaf_object_invalid(object);
   }
-
   jsSet.Add(obj);
+
   Napi::Array properties = obj.GetPropertyNames();
   uint32_t len = properties.Length();
   if (lim && len > DDWAF_MAX_CONTAINER_SIZE) {

--- a/src/convert.h
+++ b/src/convert.h
@@ -7,7 +7,6 @@
 
 #include <napi.h>
 #include <ddwaf.h>
-#include "src/jsset.h"
 
 ddwaf_object* to_ddwaf_object(
   ddwaf_object *object,

--- a/src/convert.h
+++ b/src/convert.h
@@ -7,6 +7,7 @@
 
 #include <napi.h>
 #include <ddwaf.h>
+#include "src/jsset.h"
 
 ddwaf_object* to_ddwaf_object(
   ddwaf_object *object,

--- a/src/jsset.h
+++ b/src/jsset.h
@@ -1,8 +1,14 @@
-#ifndef DD_NATIVE_APPSEC_JS_JSSET_H
+/**
+* Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+* This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
+**/
+
+#ifndef SRC_JSSET_H_
+#define SRC_JSSET_H_
+
 #include <napi.h>
-#define DD_NATIVE_APPSEC_JS_JSSET_H
 class JsSet : public Napi::Object {
-public:
+  public:
     JsSet(napi_env env, napi_value value) : Object(env, value) {}
 
     static JsSet Create(Napi::Env env) {
@@ -21,4 +27,4 @@ public:
         Get("delete").As<Napi::Function>().Call(*this, {value});
     }
 };
-#endif //DD_NATIVE_APPSEC_JS_JSSET_H
+#endif  // SRC_JSSET_H_

--- a/src/jsset.h
+++ b/src/jsset.h
@@ -8,7 +8,7 @@
 
 #include <napi.h>
 class JsSet : public Napi::Object {
-  public:
+ public:
     JsSet(napi_env env, napi_value value) : Object(env, value) {}
 
     static JsSet Create(Napi::Env env) {

--- a/src/jsset.h
+++ b/src/jsset.h
@@ -1,0 +1,24 @@
+#ifndef DD_NATIVE_APPSEC_JS_JSSET_H
+#include <napi.h>
+#define DD_NATIVE_APPSEC_JS_JSSET_H
+class JsSet : public Napi::Object {
+public:
+    JsSet(napi_env env, napi_value value) : Object(env, value) {}
+
+    static JsSet Create(Napi::Env env) {
+        return env.Global().Get("Set").As<Napi::Function>().New({}).As<JsSet>();
+    }
+
+    void Add(Napi::Value value) {
+        Get("add").As<Napi::Function>().Call(*this, {value});
+    }
+
+    bool Has(Napi::Value value) {
+        return Get("has").As<Napi::Function>().Call(*this, {value}).ToBoolean().Value();
+    }
+
+    void Delete(Napi::Value value) {
+        Get("delete").As<Napi::Function>().Call(*this, {value});
+    }
+};
+#endif //DD_NATIVE_APPSEC_JS_JSSET_H

--- a/src/jsset.h
+++ b/src/jsset.h
@@ -9,22 +9,22 @@
 #include <napi.h>
 class JsSet : public Napi::Object {
  public:
-    JsSet(napi_env env, napi_value value) : Object(env, value) {}
+  JsSet(napi_env env, napi_value value) : Object(env, value) {}
 
-    static JsSet Create(Napi::Env env) {
-        return env.Global().Get("Set").As<Napi::Function>().New({}).As<JsSet>();
-    }
+  static JsSet Create(Napi::Env env) {
+    return env.Global().Get("Set").As<Napi::Function>().New({}).As<JsSet>();
+  }
 
-    void Add(Napi::Value value) {
-        Get("add").As<Napi::Function>().Call(*this, {value});
-    }
+  void Add(Napi::Value value) {
+    Get("add").As<Napi::Function>().Call(*this, {value});
+  }
 
-    bool Has(Napi::Value value) {
-        return Get("has").As<Napi::Function>().Call(*this, {value}).ToBoolean().Value();
-    }
+  bool Has(Napi::Value value) {
+    return Get("has").As<Napi::Function>().Call(*this, {value}).ToBoolean().Value();
+  }
 
-    void Delete(Napi::Value value) {
-        Get("delete").As<Napi::Function>().Call(*this, {value});
-    }
+  void Delete(Napi::Value value) {
+    Get("delete").As<Napi::Function>().Call(*this, {value});
+  }
 };
 #endif  // SRC_JSSET_H_

--- a/test/index.js
+++ b/test/index.js
@@ -873,7 +873,7 @@ describe('limit tests', () => {
     const waf = new DDWAF(processor)
     const context = waf.createContext()
     const payload = []
-    payload.push({ paygstload })
+    payload.push({ payload })
     payload.push({ payload })
     payload.push({ payload })
 

--- a/test/index.js
+++ b/test/index.js
@@ -854,7 +854,7 @@ describe('limit tests', () => {
   it('should set as invalid circular array dependency', () => {
     const waf = new DDWAF(processor)
     const context = waf.createContext()
-    const payload = [{ key: 'value' }]
+    const payload = []
     payload.push(payload, payload, payload)
 
     const result = context.run({
@@ -865,7 +865,7 @@ describe('limit tests', () => {
     }, TIMEOUT)
 
     assert.deepStrictEqual(result.derivatives, {
-      'server.request.body.schema': [[[0], [{ key: [8] }]], { len: 4 }]
+      'server.request.body.schema': [[[0]], { len: 3 }]
     })
   })
 


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
Prevents circular dependencies when an object is converted to ddwaf object. If the circular dependency is detected, it replaces the circular dependency by `invalid` object.

### Motivation
<!-- What inspired you to submit this pull request? -->
Prevent infinite or too long iterations

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Describe how to test your changes

<!--
Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment
for testing, if the process requires more than just
running on one of the supported platforms.
-->

### Checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] The CHANGELOG.md has been updated
- [x] Unit tests have been updated and pass
- [ ] If known, an appropriate milestone has been selected

[APPSEC-51953]


[APPSEC-51953]: https://datadoghq.atlassian.net/browse/APPSEC-51953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ