### PR TITLE
Improve object properties iteration

### DIFF
--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -5,6 +5,7 @@
 #include <math.h>
 #include <napi.h>
 #include <napi-inl.h>
+#include <js_native_api.h>
 #include <ddwaf.h>
 
 #include <limits>
@@ -84,7 +85,22 @@ ddwaf_object* to_ddwaf_object_object(
     }
   }
 
-  Napi::Array properties = obj.GetPropertyNames();
+
+  napi_value result;
+  napi_status status = napi_get_all_property_names(env,
+                            obj,
+                            napi_key_own_only,
+                            napi_key_skip_symbols,
+                            napi_key_keep_numbers,
+                            &result);
+
+  if ((status) != napi_ok) {
+    mlog("Error getting object properties");
+    return nullptr;
+  }
+
+  Napi::Array properties = Napi::Array(env, result);
+
   uint32_t len = properties.Length();
   if (lim && len > DDWAF_MAX_CONTAINER_SIZE) {
     len = DDWAF_MAX_CONTAINER_SIZE;
@@ -103,11 +119,7 @@ ddwaf_object* to_ddwaf_object_object(
   for (uint32_t i = 0; i < len; ++i) {
     mlog("Getting properties");
     Napi::Value keyV = properties.Get(i);
-    if (!obj.HasOwnProperty(keyV) || !keyV.IsString()) {
-      // We avoid inherited properties here.
-      // If the key is not a String, well this is weird
-      continue;
-    }
+
     std::string key = keyV.ToString().Utf8Value();
     Napi::Value valV = obj.Get(keyV);
     mlog("Looping into ToPWArgs");


### PR DESCRIPTION
### What does this PR do?

Replace `obj.GetPropertyNames()` call with `napi_get_all_property_names()` in order to get only object's own properties.

https://nodejs.org/api/n-api.html#n_api_napi_get_property_names

### Motivation

<!-- What inspired you to submit this pull request? -->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Describe how to test your changes

<!--
Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment
for testing, if the process requires more than just
running on one of the supported platforms.
-->

### Checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] The CHANGELOG.md has been updated
- [ ] Unit tests have been updated and pass
- [ ] If known, an appropriate milestone has been selected

