### PR TITLE
v8.0.0 + drop support for NodeJs 14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
       postbuild: 'node scripts/postbuild'
       skip: 'linux-arm linux-ia32'
       target-name: 'appsec'
-      min-node-version: 14
+      min-node-version: 16
 
   static-checks:
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       postbuild: 'node scripts/postbuild'
       skip: 'linux-arm linux-ia32'
       target-name: 'appsec'
-      min-node-version: 14
+      min-node-version: 16
 
   pack:
     needs: build

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Node.js bindings for [libddwaf](https://github.com/datadog/libddwaf).
 
 This package supports the following platforms:
 
-* **Node.js version:** 14 and higher
+* **Node.js version:** 16 and higher
 * **Operating Systems:**
   * MacOS
     * x64

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "tar": "^6.1.11"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@datadog/native-appsec",
-  "version": "7.1.1",
+  "version": "8.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@datadog/native-appsec",
-      "version": "7.1.1",
+      "version": "8.0.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "node-gyp-build": "^3.9.0"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "files": [
     "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/native-appsec",
-  "version": "7.1.1",
+  "version": "8.0.0",
   "description": "Node.js bindings for libddwaf",
   "main": "index.js",
   "libddwaf_version": "1.18.0",

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,8 +2,8 @@
 * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 * This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
 **/
-// min support Node.js 14.0.0 - https://nodejs.org/api/n-api.html#node-api-version-matrix
-#define NAPI_VERSION  6
+// min support Node.js 16.0.0 - https://nodejs.org/api/n-api.html#node-api-version-matrix
+#define NAPI_VERSION  8
 #include <napi.h>
 #include <stdio.h>
 #include <ddwaf.h>


### PR DESCRIPTION
### What does this PR do?

Update package version to v8.0.0
Change NodeJS supported version to >= 16

### Motivation

Upgrade to the new version 1.18.0 (from 1.16.0) of `libddwaf`.
Drop support for Node 14

### Additional Notes

`libddwaf 1.17.0` includes a breaking change because the actions field of the result is no longer a string array but a map.