### PR TITLE
Download only `prebuilds` folder from `prebuildify` job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/download-artifact@v4
+        with:
+          name: prebuilds
       - run: npm pack
       - uses: codex-team/action-nodejs-package-info@v1.1
         id: package


### PR DESCRIPTION
### What does this PR do?

Retrieve only `prebuilds` artifact from `prebuildify` job

### Motivation

Get a valid package.