### PR TITLE
Bump libddwaf to 1.19.1

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -60,6 +60,7 @@ export class DDWAF {
   };
 
   readonly knownAddresses: Set<string>;
+  readonly knownActions: Set<string>;
 
   constructor(rules: rules, config?: {
     obfuscatorKeyRegex?: string,

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.1",
   "description": "Node.js bindings for libddwaf",
   "main": "index.js",
-  "libddwaf_version": "1.19.0",
+  "libddwaf_version": "1.19.1",
   "scripts": {
     "install": "exit 0",
     "rebuild": "node-gyp rebuild",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.1",
   "description": "Node.js bindings for libddwaf",
   "main": "index.js",
-  "libddwaf_version": "1.18.0",
+  "libddwaf_version": "1.19.0",
   "scripts": {
     "install": "exit 0",
     "rebuild": "node-gyp rebuild",

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -115,6 +115,8 @@ DDWAF::DDWAF(const Napi::CallbackInfo& info) : Napi::ObjectWrap<DDWAF>(info) {
   this->_disposed = false;
 
   this->update_known_addresses(info);
+  this->update_known_actions(info);
+
 }
 
 void DDWAF::Finalize(Napi::Env env) {
@@ -176,6 +178,7 @@ void DDWAF::update(const Napi::CallbackInfo& info) {
   this->_handle = updated_handle;
 
   this->update_known_addresses(info);
+  this->update_known_actions(info);
 }
 
 void DDWAF::update_known_addresses(const Napi::CallbackInfo& info) {
@@ -193,6 +196,23 @@ void DDWAF::update_known_addresses(const Napi::CallbackInfo& info) {
   }
 
   info.This().As<Napi::Object>().Set("knownAddresses", set);
+}
+
+void DDWAF::update_known_actions(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+
+  uint32_t size = 0;
+  const char* const* known_actions = ddwaf_known_actions(this->_handle, &size);
+
+  Napi::Value set = env.RunScript("new Set()");
+  Napi::Function set_add = set.As<Napi::Object>().Get("add").As<Napi::Function>();
+
+  for (uint32_t i = 0; i < size; ++i) {
+    Napi::String address = Napi::String::New(env, known_actions[i]);
+    set_add.Call(set, {address});
+  }
+
+  info.This().As<Napi::Object>().Set("knownActions", set);
 }
 
 Napi::Value DDWAF::createContext(const Napi::CallbackInfo& info) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -116,7 +116,6 @@ DDWAF::DDWAF(const Napi::CallbackInfo& info) : Napi::ObjectWrap<DDWAF>(info) {
 
   this->update_known_addresses(info);
   this->update_known_actions(info);
-
 }
 
 void DDWAF::Finalize(Napi::Env env) {

--- a/src/main.h
+++ b/src/main.h
@@ -28,6 +28,7 @@ class DDWAF : public Napi::ObjectWrap<DDWAF> {
 
  private:
     void update_known_addresses(const Napi::CallbackInfo& info);
+    void update_known_actions(const Napi::CallbackInfo& info);
 
     bool _disposed;
     ddwaf_handle _handle;

--- a/test/index.js
+++ b/test/index.js
@@ -185,13 +185,13 @@ describe('DDWAF', () => {
           rules_version: '1.3.0'
         },
         actions: [{
-            id: 'customredirect',
-            type: 'redirect_request',
-            parameters: {
-              status_code: '301'
-            }
+          id: 'customredirect',
+          type: 'redirect_request',
+          parameters: {
+            status_code: '301',
+            location: '/'
           }
-        ],
+        }],
         rules: [{
           id: 'block_ip',
           name: 'block ip',

--- a/test/index.js
+++ b/test/index.js
@@ -239,7 +239,7 @@ describe('DDWAF', () => {
       assert.deepStrictEqual(waf.knownAddresses, new Set([
         'http.client_ip'
       ]))
-      assert.deepStrictEqual(waf.knownAddresses, new Set([
+      assert.deepStrictEqual(waf.knownActions, new Set([
         'redirect_request'
       ]))
 

--- a/test/index.js
+++ b/test/index.js
@@ -212,7 +212,7 @@ describe('DDWAF', () => {
           ],
           transformers: [],
           on_match: [
-            'block'
+            'customredirect'
           ]
         }]
       })

--- a/test/index.js
+++ b/test/index.js
@@ -86,13 +86,7 @@ describe('DDWAF', () => {
     const waf = new DDWAF(rules)
 
     assert.deepStrictEqual(waf.knownActions, new Set([
-      'http.client_ip',
-      'server.request.headers.no_cookies',
-      'server.response.status',
-      'value_attack',
-      'key_attack',
-      'server.request.body',
-      'custom_value_attack'
+      'block_request'
     ]))
   })
 
@@ -184,12 +178,20 @@ describe('DDWAF', () => {
       assert.throws(() => waf.update({}), new Error('WAF has not been updated'))
     })
 
-    it('should update diagnostics, knownAddresses, and knownActions when updating a WAF instance with new ruleSet', () => {
+    it('should update diagnostics, knownAddresses, and knownActions when updating an instance with new ruleSet', () => {
       const waf = new DDWAF({
         version: '2.2',
         metadata: {
           rules_version: '1.3.0'
         },
+        actions: [{
+            id: 'customredirect',
+            type: 'redirect_request',
+            parameters: {
+              status_code: '301'
+            }
+          }
+        ],
         rules: [{
           id: 'block_ip',
           name: 'block ip',
@@ -229,6 +231,9 @@ describe('DDWAF', () => {
       })
       assert.deepStrictEqual(waf.knownAddresses, new Set([
         'http.client_ip'
+      ]))
+      assert.deepStrictEqual(waf.knownAddresses, new Set([
+        'redirect_request'
       ]))
 
       waf.update(rules)
@@ -284,6 +289,9 @@ describe('DDWAF', () => {
         'key_attack',
         'server.request.body',
         'custom_value_attack'
+      ]))
+      assert.deepStrictEqual(waf.knownActions, new Set([
+        'block_request'
       ]))
 
       waf.dispose()

--- a/test/index.js
+++ b/test/index.js
@@ -82,6 +82,20 @@ describe('DDWAF', () => {
     ]))
   })
 
+  it('should have knownActions', () => {
+    const waf = new DDWAF(rules)
+
+    assert.deepStrictEqual(waf.knownActions, new Set([
+      'http.client_ip',
+      'server.request.headers.no_cookies',
+      'server.response.status',
+      'value_attack',
+      'key_attack',
+      'server.request.body',
+      'custom_value_attack'
+    ]))
+  })
+
   it('should collect an attack and cleanup everything', () => {
     const waf = new DDWAF(rules)
     const context = waf.createContext()
@@ -170,7 +184,7 @@ describe('DDWAF', () => {
       assert.throws(() => waf.update({}), new Error('WAF has not been updated'))
     })
 
-    it('should update diagnostics and knownAddresses when updating a WAF instance with new ruleSet', () => {
+    it('should update diagnostics, knownAddresses, and knownActions when updating a WAF instance with new ruleSet', () => {
       const waf = new DDWAF({
         version: '2.2',
         metadata: {

--- a/test/index.js
+++ b/test/index.js
@@ -219,6 +219,13 @@ describe('DDWAF', () => {
 
       assert.deepStrictEqual(waf.diagnostics, {
         ruleset_version: '1.3.0',
+        actions: {
+          errors: {},
+          failed: [],
+          loaded: [
+            'customredirect'
+          ]
+        },
         rules: {
           addresses: {
             optional: [],


### PR DESCRIPTION
### What does this PR do?
Bump libddwaf to 1.19.1 and implement the new `ddwaf_known_actions` method