### PR TITLE
Fix release workflow - include correct prebuilds in package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,8 +38,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/download-artifact@v4
-        with:
-          name: prebuilds
       - run: npm pack
       - uses: codex-team/action-nodejs-package-info@v1.1
         id: package


### PR DESCRIPTION
### What does this PR do?

Fix release workflow, including the correct folder structure for prebuilds.

### Motivation

Get a valid package published

### Additional Notes

This fix is due to some changes in prebuildify action when merging artifacts.
