### PR TITLE
Set `GITHUB_TOKEN` permissions for `create_release` job in `release` workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,8 @@ jobs:
     needs: pack
     runs-on: ubuntu-latest
     environment: release
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
       - uses: codex-team/action-nodejs-package-info@v1.1


### PR DESCRIPTION
### What does this PR do?

Set `contents: write` permission in `create_release` job

### Motivation

After changing the default workflow permissions in the repo, it is necessary to adjust the permissions in the workflow file.

### Additional Notes

[Create release endpoint doc](https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#create-a-release)


