### PR TITLE
add static method getRulesetVersion

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -53,6 +53,7 @@ declare class DDWAFContext {
 
 export class DDWAF {
   static version(): string;
+  static getRulesetVersion(): string;
 
   readonly disposed: boolean;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,7 +15,10 @@
 #include "src/log.h"
 #include "src/convert.h"
 
-std::string DDWAF::rulesetVersion = "";
+static std::string &rulesetVersion() {
+  static std::string version;
+  return version;
+}
 
 Napi::Object DDWAF::Init(Napi::Env env, Napi::Object exports) {
   mlog("Setting up class DDWAF");
@@ -37,9 +40,9 @@ Napi::Value DDWAF::version(const Napi::CallbackInfo& info) {
   return Napi::String::New(info.Env(), ddwaf_get_version());
 }
 
-Napi::Value DDWAF::getRulesetVersion(const Napi::CallbackInfo &info){
+Napi::Value DDWAF::getRulesetVersion(const Napi::CallbackInfo &info) {
   mlog("Get ruleset version");
-  return Napi::String::New(info.Env(), rulesetVersion);
+  return Napi::String::New(info.Env(), rulesetVersion());
 }
 
 Napi::Value DDWAF::GetDisposed(const Napi::CallbackInfo& info) {
@@ -115,7 +118,7 @@ DDWAF::DDWAF(const Napi::CallbackInfo& info) : Napi::ObjectWrap<DDWAF>(info) {
   if (diagnostics_js.IsObject()) {
     Napi::Object diagObj = diagnostics_js.As<Napi::Object>();
     if (diagObj.Has("ruleset_version") && diagObj.Get("ruleset_version").IsString()) {
-      rulesetVersion = diagObj.Get("ruleset_version").ToString().Utf8Value();
+      rulesetVersion() = diagObj.Get("ruleset_version").ToString().Utf8Value();
     }
   }
 
@@ -182,7 +185,7 @@ void DDWAF::update(const Napi::CallbackInfo& info) {
   if (diagnostics_js.IsObject()) {
     Napi::Object diagObj = diagnostics_js.As<Napi::Object>();
     if (diagObj.Has("ruleset_version") && diagObj.Get("ruleset_version").IsString()) {
-      rulesetVersion = diagObj.Get("ruleset_version").ToString().Utf8Value();
+      rulesetVersion() = diagObj.Get("ruleset_version").ToString().Utf8Value();
     }
   }
 

--- a/src/main.h
+++ b/src/main.h
@@ -32,7 +32,6 @@ class DDWAF : public Napi::ObjectWrap<DDWAF> {
     void update_known_addresses(const Napi::CallbackInfo& info);
     void update_known_actions(const Napi::CallbackInfo& info);
 
-    static std::string rulesetVersion;
     bool _disposed;
     ddwaf_handle _handle;
 };

--- a/src/main.h
+++ b/src/main.h
@@ -16,6 +16,7 @@ class DDWAF : public Napi::ObjectWrap<DDWAF> {
     // Static JS methods
     static Napi::Object Init(Napi::Env env, Napi::Object exports);
     static Napi::Value version(const Napi::CallbackInfo& info);
+    static Napi::Value getRulesetVersion(const Napi::CallbackInfo &info);
 
     // JS constructor
     explicit DDWAF(const Napi::CallbackInfo& info);
@@ -31,6 +32,7 @@ class DDWAF : public Napi::ObjectWrap<DDWAF> {
     void update_known_addresses(const Napi::CallbackInfo& info);
     void update_known_actions(const Napi::CallbackInfo& info);
 
+    static std::string rulesetVersion;
     bool _disposed;
     ddwaf_handle _handle;
 };

--- a/test/index.js
+++ b/test/index.js
@@ -94,7 +94,7 @@ describe('DDWAF', () => {
 
   it('Should get waf version and rules version with wrong rules', () => {
     assert.match(DDWAF.version(), /^\d+\.\d+\.\d+$/)
-    assert.equal(DDWAF.getRulesetVersion(), '')
+    assert.equal(DDWAF.getRulesetVersion(), '1.3.1')
 
     const wrongRules = {
       version: rules.version,
@@ -200,7 +200,7 @@ describe('DDWAF', () => {
 
     it('Should get waf version and rules version after update', () => {
       assert.match(DDWAF.version(), /^\d+\.\d+\.\d+$/)
-      assert.equal(DDWAF.getRulesetVersion(), '')
+      assert.equal(DDWAF.getRulesetVersion(), '1.3.1')
 
       const waf = new DDWAF(rules)
       assert.match(DDWAF.version(), /^\d+\.\d+\.\d+$/)

--- a/test/index.js
+++ b/test/index.js
@@ -92,6 +92,27 @@ describe('DDWAF', () => {
     ]))
   })
 
+  it('Should get waf version and rules version with wrong rules', () => {
+    assert.match(DDWAF.version(), /^\d+\.\d+\.\d+$/)
+    assert.equal(DDWAF.getRulesetVersion(), '')
+
+    const wrongRules = {
+      version: rules.version,
+      metadata: rules.metadata,
+      actions: rules.actions
+    }
+
+    let waf
+
+    try {
+      waf = new DDWAF(wrongRules)
+    } catch (error) {
+      assert.match(DDWAF.version(), /^\d+\.\d+\.\d+$/)
+      assert.equal(DDWAF.getRulesetVersion(), rules.metadata.rules_version)
+      assert.equal(waf, undefined)
+    }
+  })
+
   it('should collect an attack and cleanup everything', () => {
     const waf = new DDWAF(rules)
     const context = waf.createContext()
@@ -175,6 +196,24 @@ describe('DDWAF', () => {
     it('should throw a type error when updating a WAF instance with invalid arguments', () => {
       const waf = new DDWAF(rules)
       assert.throws(() => waf.update('string'), new TypeError('First argument must be an object'))
+    })
+
+    it('Should get waf version and rules version after update', () => {
+      assert.match(DDWAF.version(), /^\d+\.\d+\.\d+$/)
+      assert.equal(DDWAF.getRulesetVersion(), '')
+
+      const waf = new DDWAF(rules)
+      assert.match(DDWAF.version(), /^\d+\.\d+\.\d+$/)
+      assert.equal(DDWAF.getRulesetVersion(), rules.metadata.rules_version)
+
+      waf.update({
+        ...rules,
+        metadata: {
+          rules_version: '2.0.0'
+        }
+      })
+
+      assert.equal(DDWAF.getRulesetVersion(), '2.0.0')
     })
 
     it('should throw an exception when WAF update has not been updated - nothing to update', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -92,20 +92,14 @@ describe('DDWAF', () => {
     ]))
   })
 
-  it('Should get waf version and rules version with wrong rules', () => {
+  it('Should get waf version and rules version with invalid rules', () => {
     assert.match(DDWAF.version(), /^\d+\.\d+\.\d+$/)
-    assert.equal(DDWAF.getRulesetVersion(), '1.3.1')
-
-    const wrongRules = {
-      version: rules.version,
-      metadata: rules.metadata,
-      actions: rules.actions
-    }
+    assert.equal(DDWAF.getRulesetVersion(), rules.metadata.rules_version)
 
     let waf
 
     try {
-      waf = new DDWAF(wrongRules)
+      waf = new DDWAF({ metadata: rules.metadata })
     } catch (error) {
       assert.match(DDWAF.version(), /^\d+\.\d+\.\d+$/)
       assert.equal(DDWAF.getRulesetVersion(), rules.metadata.rules_version)
@@ -198,13 +192,11 @@ describe('DDWAF', () => {
       assert.throws(() => waf.update('string'), new TypeError('First argument must be an object'))
     })
 
-    it('Should get waf version and rules version after update', () => {
-      assert.match(DDWAF.version(), /^\d+\.\d+\.\d+$/)
-      assert.equal(DDWAF.getRulesetVersion(), '1.3.1')
-
-      const waf = new DDWAF(rules)
+    it('Should get rules version after update', () => {
       assert.match(DDWAF.version(), /^\d+\.\d+\.\d+$/)
       assert.equal(DDWAF.getRulesetVersion(), rules.metadata.rules_version)
+
+      const waf = new DDWAF(rules)
 
       waf.update({
         ...rules,


### PR DESCRIPTION
### What does this PR do?

Add static method `getRulesetVersion` to get ruleset version after loading the WAF or update

### Motivation

WAF is unable to provide the ruleset version. However, even if the rules are invalid, we may still have access to the ruleset version and can report it later.

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Describe how to test your changes

<!--
Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment
for testing, if the process requires more than just
running on one of the supported platforms.
-->

### Checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] The CHANGELOG.md has been updated
- [ ] Unit tests have been updated and pass
- [ ] If known, an appropriate milestone has been selected

