### PR TITLE
handle case when tojson throws an error

### DIFF
--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -42,7 +42,7 @@ ddwaf_object* to_ddwaf_object_array(
       Napi::Value toJSONResult = toJSON.As<Napi::Function>().Call(arr, {});
       if (env.IsExceptionPending()) {
         env.GetAndClearPendingException();
-        toJSONResult = env.Null();
+        return ddwaf_object_invalid(object);
       }
       return to_ddwaf_object(object, env, toJSONResult, depth, lim, true, stack, metrics);
     }
@@ -96,7 +96,7 @@ ddwaf_object* to_ddwaf_object_object(
       Napi::Value toJSONResult = toJSON.As<Napi::Function>().Call(obj, {});
       if (env.IsExceptionPending()) {
         env.GetAndClearPendingException();
-        toJSONResult = env.Null();
+        return ddwaf_object_invalid(object);
       }
       return to_ddwaf_object(object, env, toJSONResult, depth, lim, true, stack, metrics);
     }

--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -39,7 +39,12 @@ ddwaf_object* to_ddwaf_object_array(
   if (!ignoreToJSON) {
     Napi::Value toJSON = arr.Get("toJSON");
     if (toJSON.IsFunction()) {
-      return to_ddwaf_object(object, env, toJSON.As<Napi::Function>().Call(arr, {}), depth, lim, true, stack, metrics);
+      Napi::Value toJSONResult = toJSON.As<Napi::Function>().Call(arr, {});
+      if (env.IsExceptionPending()) {
+        env.GetAndClearPendingException();
+        toJSONResult = env.Null();
+      }
+      return to_ddwaf_object(object, env, toJSONResult, depth, lim, true, stack, metrics);
     }
   }
 
@@ -88,7 +93,12 @@ ddwaf_object* to_ddwaf_object_object(
   if (!ignoreToJSON) {
     Napi::Value toJSON = obj.Get("toJSON");
     if (toJSON.IsFunction()) {
-      return to_ddwaf_object(object, env, toJSON.As<Napi::Function>().Call(obj, {}), depth, lim, true, stack, metrics);
+      Napi::Value toJSONResult = toJSON.As<Napi::Function>().Call(obj, {});
+      if (env.IsExceptionPending()) {
+        env.GetAndClearPendingException();
+        toJSONResult = env.Null();
+      }
+      return to_ddwaf_object(object, env, toJSONResult, depth, lim, true, stack, metrics);
     }
   }
 

--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -41,6 +41,7 @@ ddwaf_object* to_ddwaf_object_array(
     if (toJSON.IsFunction()) {
       Napi::Value toJSONResult = toJSON.As<Napi::Function>().Call(arr, {});
       if (env.IsExceptionPending()) {
+        mlog("Exception pending");
         env.GetAndClearPendingException();
         return ddwaf_object_invalid(object);
       }
@@ -95,6 +96,7 @@ ddwaf_object* to_ddwaf_object_object(
     if (toJSON.IsFunction()) {
       Napi::Value toJSONResult = toJSON.As<Napi::Function>().Call(obj, {});
       if (env.IsExceptionPending()) {
+        mlog("Exception pending");
         env.GetAndClearPendingException();
         return ddwaf_object_invalid(object);
       }

--- a/test/index.js
+++ b/test/index.js
@@ -1303,7 +1303,7 @@ describe('limit tests', () => {
     })
   })
 
-  it('should handle toJSON errors gracefully with null fallback', () => {
+  it('should handle toJSON errors gracefully with invalid fallback', () => {
     const body = {
       a: {
         toJSON: function () {

--- a/test/index.js
+++ b/test/index.js
@@ -1327,7 +1327,7 @@ describe('limit tests', () => {
     assert.deepStrictEqual(result.derivatives, {
       'server.request.body.schema': [
         {
-          a: [1],
+          a: [0],
           c: [8]
         }
       ]

--- a/test/index.js
+++ b/test/index.js
@@ -1303,6 +1303,37 @@ describe('limit tests', () => {
     })
   })
 
+  it('should handle toJSON errors gracefully with null fallback', () => {
+    const body = {
+      a: {
+        toJSON: function () {
+          throw new Error('error')
+        }
+      },
+      c: 'c'
+    }
+
+    const waf = new DDWAF(processor)
+    const context = waf.createContext()
+    const result = context.run({
+      persistent: {
+        'server.request.body': body,
+        'waf.context.processor': {
+          'extract-schema': true
+        }
+      }
+    }, TIMEOUT)
+
+    assert.deepStrictEqual(result.derivatives, {
+      'server.request.body.schema': [
+        {
+          a: [1],
+          c: [8]
+        }
+      ]
+    })
+  })
+
   it('should truncate string values exceeding maximum length', () => {
     const waf = new DDWAF(rules)
 


### PR DESCRIPTION
### What does this PR do?

Handle `toJSON` errors gracefully with null value as a fallback

### Motivation

When `toJSON` throws an error, the application currently stops with a fatal error. 
This PR changes the behavior so that instead of crashing, we fall back to `null` if an error occurs while executing `toJSON`

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Describe how to test your changes

<!--
Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment
for testing, if the process requires more than just
running on one of the supported platforms.
-->

### Checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] The CHANGELOG.md has been updated
- [x] Unit tests have been updated and pass
- [ ] If known, an appropriate milestone has been selected

