### PR TITLE
Update libddwaf to v1.24.1

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -56,6 +56,8 @@ export class DDWAF {
 
   readonly disposed: boolean;
 
+  readonly configPaths: string[];
+
   readonly diagnostics: {
     ruleset_version?: string,
     rules?: diagnosticsResult,

--- a/index.d.ts
+++ b/index.d.ts
@@ -70,12 +70,13 @@ export class DDWAF {
   readonly knownAddresses: Set<string>;
   readonly knownActions: Set<string>;
 
-  constructor(rules: rules, config?: {
+  constructor(rules: rules, rulesPath: string, config?: {
     obfuscatorKeyRegex?: string,
     obfuscatorValueRegex?: string
   });
 
-  update(rules: rules): void;
+  createOrUpdateConfig(config: rules, path: string): boolean;
+  removeConfig(path: string): boolean;
 
   createContext(): DDWAFContext;
   dispose(): void;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "8.5.2",
   "description": "Node.js bindings for libddwaf",
   "main": "index.js",
-  "libddwaf_version": "1.22.0",
+  "libddwaf_version": "1.24.1",
   "scripts": {
     "install": "exit 0",
     "rebuild": "node-gyp rebuild",

--- a/src/log.h
+++ b/src/log.h
@@ -4,7 +4,7 @@
 **/
 #ifndef SRC_LOG_H_
 #define SRC_LOG_H_
-#define DEBUG 1
+#define DEBUG 0
 #include <cstdio>
 
 #if DEBUG == 1

--- a/src/log.h
+++ b/src/log.h
@@ -4,7 +4,7 @@
 **/
 #ifndef SRC_LOG_H_
 #define SRC_LOG_H_
-#define DEBUG 0
+#define DEBUG 1
 #include <cstdio>
 
 #if DEBUG == 1

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -145,6 +145,7 @@ void DDWAF::Finalize(Napi::Env env) {
     return;
   }
   ddwaf_destroy(this->_handle);
+  ddwaf_builder_destroy(this->_builder);
   this->_disposed = true;
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,6 +22,7 @@ Napi::Object DDWAF::Init(Napi::Env env, Napi::Object exports) {
     StaticMethod<&DDWAF::version>("version"),
     InstanceMethod<&DDWAF::update_config>("createOrUpdateConfig"),
     InstanceMethod<&DDWAF::remove_config>("removeConfig"),
+    InstanceAccessor("configPaths", &DDWAF::GetConfigPaths, nullptr, napi_enumerable),
     InstanceMethod<&DDWAF::createContext>("createContext"),
     InstanceMethod<&DDWAF::dispose>("dispose"),
     InstanceAccessor("disposed", &DDWAF::GetDisposed, nullptr, napi_enumerable),
@@ -264,6 +265,23 @@ Napi::Value DDWAF::remove_config(const Napi::CallbackInfo& info) {
   }
 
   return Napi::Boolean::New(env, true);
+}
+
+Napi::Value DDWAF::GetConfigPaths(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+
+  if (this->_disposed) {
+    return Napi::Array::New(info.Env(), 0);
+  }
+
+  ddwaf_object config_paths;
+  uint32_t path_count = ddwaf_builder_get_config_paths(this->_builder, &config_paths, nullptr, 0);
+
+  Napi::Value config_paths_js = from_ddwaf_object(&config_paths, info.Env());
+
+  ddwaf_object_free(&config_paths);
+
+  return config_paths_js;
 }
 
 void DDWAF::update_known_addresses(const Napi::CallbackInfo& info) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -268,13 +268,13 @@ Napi::Value DDWAF::GetConfigPaths(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
 
   if (this->_disposed) {
-    return Napi::Array::New(info.Env(), 0);
+    return Napi::Array::New(env, 0);
   }
 
   ddwaf_object config_paths;
-  uint32_t path_count = ddwaf_builder_get_config_paths(this->_builder, &config_paths, nullptr, 0);
+  ddwaf_builder_get_config_paths(this->_builder, &config_paths, nullptr, 0);
 
-  Napi::Value config_paths_js = from_ddwaf_object(&config_paths, info.Env());
+  Napi::Value config_paths_js = from_ddwaf_object(&config_paths, env);
 
   ddwaf_object_free(&config_paths);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -208,7 +208,8 @@ Napi::Value DDWAF::update_config(const Napi::CallbackInfo& info) {
 
   if (updated_handle == nullptr) {
     mlog("DDWAF updated handle is null");
-    return Napi::Boolean::New(env, false);
+    Napi::Error::New(env, "WAF has not been updated").ThrowAsJavaScriptException();
+    return;
   }
 
   mlog("New DDWAF updated instance")
@@ -258,7 +259,8 @@ Napi::Value DDWAF::remove_config(const Napi::CallbackInfo& info) {
 
   if (updated_handle == nullptr) {
     mlog("DDWAF handle after removing config is null");
-    return Napi::Boolean::New(env, false);
+    Napi::Error::New(env, "WAF has not been updated").ThrowAsJavaScriptException();
+    return;
   }
 
   mlog("New DDWAF updated instance")

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -104,13 +104,12 @@ DDWAF::DDWAF(const Napi::CallbackInfo& info) : Napi::ObjectWrap<DDWAF>(info) {
   to_ddwaf_object(&rules, env, info[0], 0, false, false, JsSet::Create(env), nullptr);
   std::string config_path_str = info[1].As<Napi::String>().Utf8Value();
   const char* config_path = config_path_str.c_str();
-  uint32_t config_path_len = (uint32_t)strlen(config_path);
 
   ddwaf_object diagnostics;
 
   mlog("Init Builder");
   ddwaf_builder builder = ddwaf_builder_init(&waf_config);
-  bool result = ddwaf_builder_add_or_update_config(builder, config_path, config_path_len, &rules, &diagnostics);
+  bool result = ddwaf_builder_add_or_update_config(builder, LSTRARG(config_path), &rules, &diagnostics);
 
   ddwaf_object_free(&rules);
 
@@ -186,12 +185,11 @@ Napi::Value DDWAF::update_config(const Napi::CallbackInfo& info) {
   mlog("Obtaining config update path");
   std::string config_path_str = info[1].As<Napi::String>().Utf8Value();
   const char* config_path = config_path_str.c_str();
-  uint32_t config_path_len = (uint32_t)strlen(config_path);
 
   ddwaf_object diagnostics;
 
   mlog("Applying new config to builder");
-  bool update_result = ddwaf_builder_add_or_update_config(this->_builder, config_path, config_path_len, &update, &diagnostics);
+  bool update_result = ddwaf_builder_add_or_update_config(this->_builder, LSTRARG(config_path), &update, &diagnostics);
 
   Napi::Value diagnostics_js = from_ddwaf_object(&diagnostics, env);
   info.This().As<Napi::Object>().Set("diagnostics", diagnostics_js);
@@ -242,10 +240,9 @@ Napi::Value DDWAF::remove_config(const Napi::CallbackInfo& info) {
   mlog("Obtaining config remove path");
   std::string config_path_str = info[0].As<Napi::String>().Utf8Value();
   const char* config_path = config_path_str.c_str();
-  uint32_t config_path_len = (uint32_t)strlen(config_path);
 
   mlog("Applying removed config to builder");
-  bool remove_result = ddwaf_builder_remove_config(this->_builder, config_path, config_path_len);
+  bool remove_result = ddwaf_builder_remove_config(this->_builder, LSTRARG(config_path));
 
   if (!remove_result) {
     mlog("DDWAF Builder remove config has failed");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,7 +20,8 @@ Napi::Object DDWAF::Init(Napi::Env env, Napi::Object exports) {
   mlog("Setting up class DDWAF");
   Napi::Function func = DefineClass(env, "DDWAF", {
     StaticMethod<&DDWAF::version>("version"),
-    InstanceMethod<&DDWAF::update>("update"),
+    InstanceMethod<&DDWAF::update_config>("createOrUpdateConfig"),
+    InstanceMethod<&DDWAF::remove_config>("removeConfig"),
     InstanceMethod<&DDWAF::createContext>("createContext"),
     InstanceMethod<&DDWAF::dispose>("dispose"),
     InstanceAccessor("disposed", &DDWAF::GetDisposed, nullptr, napi_enumerable),
@@ -42,12 +43,18 @@ Napi::Value DDWAF::GetDisposed(const Napi::CallbackInfo& info) {
 DDWAF::DDWAF(const Napi::CallbackInfo& info) : Napi::ObjectWrap<DDWAF>(info) {
   Napi::Env env = info.Env();
   size_t arg_len = info.Length();
-  if (arg_len < 1) {
-    Napi::Error::New(env, "Wrong number of arguments, expected at least 1").ThrowAsJavaScriptException();
+  if (arg_len < 2) {
+    Napi::Error::New(env, "Wrong number of arguments, expected at least 2").ThrowAsJavaScriptException();
     return;
   }
+
   if (!info[0].IsObject()) {
     Napi::TypeError::New(env, "First argument must be an object").ThrowAsJavaScriptException();
+    return;
+  }
+
+  if (!info[1].IsString()) {
+    Napi::TypeError::New(env, "Second argument must be a string").ThrowAsJavaScriptException();
     return;
   }
 
@@ -57,14 +64,14 @@ DDWAF::DDWAF(const Napi::CallbackInfo& info) : Napi::ObjectWrap<DDWAF>(info) {
   std::string key_regex_str;
   std::string value_regex_str;
 
-  if (arg_len >= 2) {  // TODO(@simon-id): there is a bug here ?
+  if (arg_len >= 3) {  // TODO(@simon-id): there is a bug here ?
     // TODO(@simon-id) make a macro here someday
-    if (!info[1].IsObject()) {
+    if (!info[2].IsObject()) {
       Napi::TypeError::New(env, "Second argument must be an object").ThrowAsJavaScriptException();
       return;
     }
 
-    Napi::Object config = info[1].ToObject();
+    Napi::Object config = info[2].ToObject();
 
     if (config.Has("obfuscatorKeyRegex")) {
       Napi::Value key_regex = config.Get("obfuscatorKeyRegex");
@@ -94,11 +101,16 @@ DDWAF::DDWAF(const Napi::CallbackInfo& info) : Napi::ObjectWrap<DDWAF>(info) {
   ddwaf_object rules;
   mlog("building rules");
   to_ddwaf_object(&rules, env, info[0], 0, false, false, JsSet::Create(env), nullptr);
+  std::string config_path_str = info[1].As<Napi::String>().Utf8Value();
+  const char* config_path = config_path_str.c_str();
+  uint32_t config_path_len = (uint32_t)strlen(config_path);
 
   ddwaf_object diagnostics;
 
-  mlog("Init WAF");
-  ddwaf_handle handle = ddwaf_init(&rules, &waf_config, &diagnostics);
+  mlog("Init Builder");
+  ddwaf_builder builder = ddwaf_builder_init(&waf_config);
+  bool result = ddwaf_builder_add_or_update_config(builder, config_path, config_path_len, &rules, &diagnostics);
+
   ddwaf_object_free(&rules);
 
   Napi::Value diagnostics_js = from_ddwaf_object(&diagnostics, env);
@@ -106,11 +118,20 @@ DDWAF::DDWAF(const Napi::CallbackInfo& info) : Napi::ObjectWrap<DDWAF>(info) {
 
   ddwaf_object_free(&diagnostics);
 
+  if (!result) {
+    Napi::Error::New(env, "Invalid rules").ThrowAsJavaScriptException();
+    return;
+  }
+
+  mlog("Init WAF");
+  ddwaf_handle handle = ddwaf_builder_build_instance(builder);
+
   if (handle == nullptr) {
     Napi::Error::New(env, "Invalid rules").ThrowAsJavaScriptException();
     return;
   }
 
+  this->_builder = builder;
   this->_handle = handle;
   this->_disposed = false;
 
@@ -132,44 +153,62 @@ void DDWAF::dispose(const Napi::CallbackInfo& info) {
   return this->Finalize(info.Env());
 }
 
-void DDWAF::update(const Napi::CallbackInfo& info) {
-  mlog("calling update on DDWAF");
+Napi::Value DDWAF::update_config(const Napi::CallbackInfo& info) {
+  mlog("Calling update config on DDWAF");
 
   Napi::Env env = info.Env();
 
   if (this->_disposed) {
     Napi::Error::New(env, "Could not update a disposed WAF instance").ThrowAsJavaScriptException();
-    return;
+    return env.Undefined();
   }
 
-  if (info.Length() < 1) {
-    Napi::Error::New(env, "Wrong number of arguments, expected at least 1").ThrowAsJavaScriptException();
-    return;
+  if (info.Length() < 2) {
+    Napi::Error::New(env, "Wrong number of arguments, expected at least 2").ThrowAsJavaScriptException();
+    return env.Undefined();
   }
+
   if (!info[0].IsObject()) {
     Napi::TypeError::New(env, "First argument must be an object").ThrowAsJavaScriptException();
-    return;
+    return env.Undefined();
+  }
+
+  if (!info[1].IsString()) {
+    Napi::TypeError::New(env, "Second argument must be a string").ThrowAsJavaScriptException();
+    return env.Undefined();
   }
 
   ddwaf_object update;
-  mlog("building rules update");
+  mlog("Building config update");
   to_ddwaf_object(&update, env, info[0], 0, false, false, JsSet::Create(env), nullptr);
+
+  mlog("Obtaining config update path");
+  std::string config_path_str = info[1].As<Napi::String>().Utf8Value();
+  const char* config_path = config_path_str.c_str();
+  uint32_t config_path_len = (uint32_t)strlen(config_path);
 
   ddwaf_object diagnostics;
 
-  mlog("Update DDWAF instance");
-  ddwaf_handle updated_handle = ddwaf_update(this->_handle, &update, &diagnostics);
-  ddwaf_object_free(&update);
+  mlog("Applying new config to builder");
+  bool update_result = ddwaf_builder_add_or_update_config(this->_builder, config_path, config_path_len, &update, &diagnostics);
 
   Napi::Value diagnostics_js = from_ddwaf_object(&diagnostics, env);
   info.This().As<Napi::Object>().Set("diagnostics", diagnostics_js);
 
   ddwaf_object_free(&diagnostics);
 
+  if (!update_result) {
+    mlog("DDWAF Builder update config has failed");
+    return Napi::Boolean::New(env, false);
+  }
+
+  mlog("Update DDWAF instance");
+  ddwaf_handle updated_handle = ddwaf_builder_build_instance(this->_builder);
+  ddwaf_object_free(&update);
+
   if (updated_handle == nullptr) {
     mlog("DDWAF updated handle is null");
-    Napi::Error::New(env, "WAF has not been updated").ThrowAsJavaScriptException();
-    return;
+    return Napi::Boolean::New(env, false);
   }
 
   mlog("New DDWAF updated instance")
@@ -178,6 +217,57 @@ void DDWAF::update(const Napi::CallbackInfo& info) {
 
   this->update_known_addresses(info);
   this->update_known_actions(info);
+  return Napi::Boolean::New(env, true);
+}
+
+Napi::Value DDWAF::remove_config(const Napi::CallbackInfo& info) {
+  mlog("Calling remove config on DDWAF");
+
+  Napi::Env env = info.Env();
+
+  if (this->_disposed) {
+    Napi::Error::New(env, "Could not update a disposed WAF instance").ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+
+  if (info.Length() < 1) {
+    Napi::Error::New(env, "Wrong number of arguments, expected at least 1").ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+
+  if (!info[0].IsString()) {
+    Napi::TypeError::New(env, "First argument must be a string").ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+
+  mlog("Obtaining config remove path");
+  std::string config_path_str = info[0].As<Napi::String>().Utf8Value();
+  const char* config_path = config_path_str.c_str();
+  uint32_t config_path_len = (uint32_t)strlen(config_path);
+
+  mlog("Applying removed config to builder");
+  bool remove_result = ddwaf_builder_remove_config(this->_builder, config_path, config_path_len);
+
+  if (!remove_result) {
+    mlog("DDWAF Builder remove config has failed");
+    return Napi::Boolean::New(env, false);
+  }
+
+  mlog("Update DDWAF instance");
+  ddwaf_handle updated_handle = ddwaf_builder_build_instance(this->_builder);
+
+  if (updated_handle == nullptr) {
+    mlog("DDWAF handle after removing config is null");
+    return Napi::Boolean::New(env, false);
+  }
+
+  mlog("New DDWAF updated instance")
+  ddwaf_destroy(this->_handle);
+  this->_handle = updated_handle;
+
+  this->update_known_addresses(info);
+  this->update_known_actions(info);
+  return Napi::Boolean::New(env, true);
 }
 
 void DDWAF::update_known_addresses(const Napi::CallbackInfo& info) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -206,18 +206,15 @@ Napi::Value DDWAF::update_config(const Napi::CallbackInfo& info) {
   ddwaf_handle updated_handle = ddwaf_builder_build_instance(this->_builder);
   ddwaf_object_free(&update);
 
-  if (updated_handle == nullptr) {
-    mlog("DDWAF updated handle is null");
-    Napi::Error::New(env, "WAF has not been updated").ThrowAsJavaScriptException();
-    return;
+  if (updated_handle != nullptr) {
+    mlog("New DDWAF updated instance")
+    ddwaf_destroy(this->_handle);
+    this->_handle = updated_handle;
+
+    this->update_known_addresses(info);
+    this->update_known_actions(info);
   }
 
-  mlog("New DDWAF updated instance")
-  ddwaf_destroy(this->_handle);
-  this->_handle = updated_handle;
-
-  this->update_known_addresses(info);
-  this->update_known_actions(info);
   return Napi::Boolean::New(env, true);
 }
 
@@ -257,18 +254,15 @@ Napi::Value DDWAF::remove_config(const Napi::CallbackInfo& info) {
   mlog("Update DDWAF instance");
   ddwaf_handle updated_handle = ddwaf_builder_build_instance(this->_builder);
 
-  if (updated_handle == nullptr) {
-    mlog("DDWAF handle after removing config is null");
-    Napi::Error::New(env, "WAF has not been updated").ThrowAsJavaScriptException();
-    return;
+  if (updated_handle != nullptr) {
+    mlog("New DDWAF updated instance")
+    ddwaf_destroy(this->_handle);
+    this->_handle = updated_handle;
+
+    this->update_known_addresses(info);
+    this->update_known_actions(info);
   }
 
-  mlog("New DDWAF updated instance")
-  ddwaf_destroy(this->_handle);
-  this->_handle = updated_handle;
-
-  this->update_known_addresses(info);
-  this->update_known_actions(info);
   return Napi::Boolean::New(env, true);
 }
 

--- a/src/main.h
+++ b/src/main.h
@@ -23,6 +23,7 @@ class DDWAF : public Napi::ObjectWrap<DDWAF> {
     // JS instance methods
     Napi::Value update_config(const Napi::CallbackInfo& info);
     Napi::Value remove_config(const Napi::CallbackInfo& info);
+    Napi::Value GetConfigPaths(const Napi::CallbackInfo& info);
     Napi::Value createContext(const Napi::CallbackInfo& info);
     void Finalize(Napi::Env env);
     Napi::Value GetDisposed(const Napi::CallbackInfo& info);

--- a/src/main.h
+++ b/src/main.h
@@ -21,7 +21,8 @@ class DDWAF : public Napi::ObjectWrap<DDWAF> {
     explicit DDWAF(const Napi::CallbackInfo& info);
 
     // JS instance methods
-    void update(const Napi::CallbackInfo& info);
+    Napi::Value update_config(const Napi::CallbackInfo& info);
+    Napi::Value remove_config(const Napi::CallbackInfo& info);
     Napi::Value createContext(const Napi::CallbackInfo& info);
     void Finalize(Napi::Env env);
     Napi::Value GetDisposed(const Napi::CallbackInfo& info);
@@ -32,6 +33,7 @@ class DDWAF : public Napi::ObjectWrap<DDWAF> {
     void update_known_actions(const Napi::CallbackInfo& info);
 
     bool _disposed;
+    ddwaf_builder _builder;
     ddwaf_handle _handle;
 };
 

--- a/src/main.h
+++ b/src/main.h
@@ -8,6 +8,8 @@
 #include <ddwaf.h>
 #include "src/metrics.h"
 
+#define LSTRARG(value) value, (uint32_t)strlen(value)
+
 // TODO(@vdeturckheim): logs with ddwaf_set_log_cb
 // TODO(@vdeturckheim): fix issue when used with workers
 

--- a/test/index.js
+++ b/test/index.js
@@ -151,7 +151,7 @@ describe('DDWAF', () => {
   })
 
   describe('WAF update', () => {
-    it('should throw an error when updating a disposed WAF instance', () => {
+    it('should throw an error when updating configuration on a disposed WAF instance', () => {
       const waf = new DDWAF(rules, 'recommended')
       waf.dispose()
       assert.throws(
@@ -159,17 +159,17 @@ describe('DDWAF', () => {
         new Error('Could not update a disposed WAF instance'))
     })
 
-    it('should throw an error when updating a WAF instance with no arguments', () => {
+    it('should throw an error when updating configuration with no arguments', () => {
       const waf = new DDWAF(rules, 'recommended')
       assert.throws(() => waf.createOrUpdateConfig(), new Error('Wrong number of arguments, expected at least 2'))
     })
 
-    it('should throw an error when updating a WAF instance with just one argument', () => {
+    it('should throw an error when updating configuration with just one argument', () => {
       const waf = new DDWAF(rules, 'recommended')
       assert.throws(() => waf.createOrUpdateConfig({}), new Error('Wrong number of arguments, expected at least 2'))
     })
 
-    it('should throw a type error when updating a WAF instance with invalid arguments', () => {
+    it('should throw a type error when updating configuration with invalid arguments', () => {
       const waf = new DDWAF(rules, 'recommended')
       assert.throws(
         () => waf.createOrUpdateConfig('string', 'config/update'),
@@ -177,12 +177,82 @@ describe('DDWAF', () => {
       )
     })
 
-    it('should throw an exception when WAF update has not been updated - nothing to update', () => {
+    it('should return false when updating configuration with invalid configuration', () => {
+      const waf = new DDWAF(rules, 'recommended')
+      assert.strictEqual(waf.createOrUpdateConfig({}, 'config/update'), false)
+    })
+
+    it('should return true when updating configuration', () => {
+      const waf = new DDWAF(rules, 'recommended')
+      const newConfig = {
+        version: '2.2',
+        metadata: {
+          rules_version: '1.3.0'
+        },
+        actions: [{
+          id: 'customredirect',
+          type: 'redirect_request',
+          parameters: {
+            status_code: '301',
+            location: '/'
+          }
+        }],
+        rules: [{
+          id: 'block_ip_original',
+          name: 'block ip',
+          tags: {
+            type: 'ip_addresses',
+            category: 'blocking'
+          },
+          conditions: [
+            {
+              parameters: {
+                inputs: [
+                  { address: 'http.client_ip' }
+                ],
+                data: 'blocked_ips'
+              },
+              operator: 'ip_match'
+            }
+          ],
+          transformers: [],
+          on_match: [
+            'customredirect'
+          ]
+        }]
+      }
+      assert.strictEqual(waf.createOrUpdateConfig(newConfig, 'config/update'), true)
+    })
+
+    it('should throw an error when removing a configuration on a disposed WAF instance', () => {
+      const waf = new DDWAF(rules, 'recommended')
+      waf.dispose()
+      assert.throws(
+        () => waf.removeConfig('config/update'),
+        new Error('Could not update a disposed WAF instance'))
+    })
+
+    it('should throw an error when removing a configuration with no arguments', () => {
+      const waf = new DDWAF(rules, 'recommended')
+      assert.throws(() => waf.removeConfig(), new Error('Wrong number of arguments, expected at least 1'))
+    })
+
+    it('should throw a type error when removing a configuration with invalid arguments', () => {
       const waf = new DDWAF(rules, 'recommended')
       assert.throws(
-        () => waf.createOrUpdateConfig({}, 'config/update'),
-        new Error('WAF has not been updated')
+        () => waf.removeConfig(null),
+        new TypeError('First argument must be a string')
       )
+    })
+
+    it('should return true when removing an existing configuration', () => {
+      const waf = new DDWAF(rules, 'recommended')
+      assert.strictEqual(waf.removeConfig('recommended'), true)
+    })
+
+    it('should return false when removing a non-existing configuration', () => {
+      const waf = new DDWAF(rules, 'recommended')
+      assert.strictEqual(waf.removeConfig('config/update'), false)
     })
 
     it('should update diagnostics, knownAddresses, and knownActions when updating an instance with new ruleSet', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -20,12 +20,13 @@ describe('DDWAF', () => {
   })
 
   it('should have diagnostics', () => {
-    const waf = new DDWAF(rules)
+    const waf = new DDWAF(rules, 'recommended')
 
     assert.deepStrictEqual(waf.diagnostics, {
       ruleset_version: '1.3.1',
       actions: {
         errors: {},
+        warnings: {},
         failed: [],
         loaded: [
           'customblock'
@@ -33,18 +34,6 @@ describe('DDWAF', () => {
         skipped: []
       },
       rules: {
-        addresses: {
-          optional: [],
-          required: [
-            'http.client_ip',
-            'server.request.headers.no_cookies',
-            'server.response.status',
-            'value_attack',
-            'key_attack',
-            'custom_value_attack',
-            'server.request.body'
-          ]
-        },
         loaded: [
           'block_ip',
           'value_attack',
@@ -65,13 +54,14 @@ describe('DDWAF', () => {
             'invalid_2',
             'invalid_3'
           ]
-        }
+        },
+        warnings: {}
       }
     })
   })
 
   it('should have knownAddresses', () => {
-    const waf = new DDWAF(rules)
+    const waf = new DDWAF(rules, 'recommended')
 
     assert.deepStrictEqual(waf.knownAddresses, new Set([
       'http.client_ip',
@@ -85,7 +75,7 @@ describe('DDWAF', () => {
   })
 
   it('should have knownActions', () => {
-    const waf = new DDWAF(rules)
+    const waf = new DDWAF(rules, 'recommended')
 
     assert.deepStrictEqual(waf.knownActions, new Set([
       'block_request'
@@ -93,7 +83,7 @@ describe('DDWAF', () => {
   })
 
   it('should collect an attack and cleanup everything', () => {
-    const waf = new DDWAF(rules)
+    const waf = new DDWAF(rules, 'recommended')
     const context = waf.createContext()
     const payload = {
       persistent: {
@@ -129,7 +119,7 @@ describe('DDWAF', () => {
   })
 
   it('should collect different attacks on ephemeral addresses', () => {
-    const waf = new DDWAF(rules)
+    const waf = new DDWAF(rules, 'recommended')
     const context = waf.createContext()
     let result = context.run({
       ephemeral: {
@@ -162,24 +152,37 @@ describe('DDWAF', () => {
 
   describe('WAF update', () => {
     it('should throw an error when updating a disposed WAF instance', () => {
-      const waf = new DDWAF(rules)
+      const waf = new DDWAF(rules, 'recommended')
       waf.dispose()
-      assert.throws(() => waf.update(rules), new Error('Could not update a disposed WAF instance'))
+      assert.throws(
+        () => waf.createOrUpdateConfig(rules, 'config/update'),
+        new Error('Could not update a disposed WAF instance'))
     })
 
     it('should throw an error when updating a WAF instance with no arguments', () => {
-      const waf = new DDWAF(rules)
-      assert.throws(() => waf.update(), new Error('Wrong number of arguments, expected at least 1'))
+      const waf = new DDWAF(rules, 'recommended')
+      assert.throws(() => waf.createOrUpdateConfig(), new Error('Wrong number of arguments, expected at least 2'))
+    })
+
+    it('should throw an error when updating a WAF instance with just one argument', () => {
+      const waf = new DDWAF(rules, 'recommended')
+      assert.throws(() => waf.createOrUpdateConfig({}), new Error('Wrong number of arguments, expected at least 2'))
     })
 
     it('should throw a type error when updating a WAF instance with invalid arguments', () => {
-      const waf = new DDWAF(rules)
-      assert.throws(() => waf.update('string'), new TypeError('First argument must be an object'))
+      const waf = new DDWAF(rules, 'recommended')
+      assert.throws(
+        () => waf.createOrUpdateConfig('string', 'config/update'),
+        new TypeError('First argument must be an object')
+      )
     })
 
     it('should throw an exception when WAF update has not been updated - nothing to update', () => {
-      const waf = new DDWAF(rules)
-      assert.throws(() => waf.update({}), new Error('WAF has not been updated'))
+      const waf = new DDWAF(rules, 'recommended')
+      assert.throws(
+        () => waf.createOrUpdateConfig({}, 'config/update'),
+        new Error('WAF has not been updated')
+      )
     })
 
     it('should update diagnostics, knownAddresses, and knownActions when updating an instance with new ruleSet', () => {
@@ -197,7 +200,7 @@ describe('DDWAF', () => {
           }
         }],
         rules: [{
-          id: 'block_ip',
+          id: 'block_ip_original',
           name: 'block ip',
           tags: {
             type: 'ip_addresses',
@@ -219,12 +222,13 @@ describe('DDWAF', () => {
             'customredirect'
           ]
         }]
-      })
+      }, 'new_ruleset')
 
       assert.deepStrictEqual(waf.diagnostics, {
         ruleset_version: '1.3.0',
         actions: {
           errors: {},
+          warnings: {},
           failed: [],
           loaded: [
             'customredirect'
@@ -232,14 +236,11 @@ describe('DDWAF', () => {
           skipped: []
         },
         rules: {
-          addresses: {
-            optional: [],
-            required: ['http.client_ip']
-          },
-          loaded: ['block_ip'],
+          loaded: ['block_ip_original'],
           failed: [],
           skipped: [],
-          errors: {}
+          errors: {},
+          warnings: {}
         }
       })
       assert.deepStrictEqual(waf.knownAddresses, new Set([
@@ -249,11 +250,12 @@ describe('DDWAF', () => {
         'redirect_request'
       ]))
 
-      waf.update(rules)
+      waf.createOrUpdateConfig(rules, 'config/update')
       assert.deepStrictEqual(waf.diagnostics, {
         ruleset_version: '1.3.1',
         actions: {
           errors: {},
+          warnings: {},
           failed: [],
           loaded: [
             'customblock'
@@ -261,18 +263,6 @@ describe('DDWAF', () => {
           skipped: []
         },
         rules: {
-          addresses: {
-            optional: [],
-            required: [
-              'http.client_ip',
-              'server.request.headers.no_cookies',
-              'server.response.status',
-              'value_attack',
-              'key_attack',
-              'custom_value_attack',
-              'server.request.body'
-            ]
-          },
           loaded: [
             'block_ip',
             'value_attack',
@@ -293,7 +283,8 @@ describe('DDWAF', () => {
               'invalid_2',
               'invalid_3'
             ]
-          }
+          },
+          warnings: {}
         }
       })
       assert.deepStrictEqual(waf.knownAddresses, new Set([
@@ -306,7 +297,8 @@ describe('DDWAF', () => {
         'custom_value_attack'
       ]))
       assert.deepStrictEqual(waf.knownActions, new Set([
-        'block_request'
+        'block_request',
+        'redirect_request'
       ]))
 
       waf.dispose()
@@ -320,7 +312,7 @@ describe('DDWAF', () => {
         }
       }
 
-      const waf = new DDWAF(rules)
+      const waf = new DDWAF(rules, 'recommended')
       const context = waf.createContext()
       const resultBeforeUpdatingRuleData = context.run(payload, TIMEOUT)
       assert(!resultBeforeUpdatingRuleData.status)
@@ -335,7 +327,7 @@ describe('DDWAF', () => {
         ]
       }
 
-      waf.update(updateWithRulesData)
+      waf.createOrUpdateConfig(updateWithRulesData, 'config/update')
       const contextWithRuleData = waf.createContext()
       const resultAfterUpdatingRuleData = contextWithRuleData.run(payload, TIMEOUT)
 
@@ -385,7 +377,7 @@ describe('DDWAF', () => {
               value_attack: 'matchall'
             }
           }
-          const waf = new DDWAF(rules)
+          const waf = new DDWAF(rules, 'recommended')
           const contextToggledOn = waf.createContext()
 
           const resultToggledOn = contextToggledOn.run(payload, TIMEOUT)
@@ -398,7 +390,7 @@ describe('DDWAF', () => {
             rules_override: testData.rulesOverride
           }
 
-          waf.update(updateWithRulesOverride)
+          waf.createOrUpdateConfig(updateWithRulesOverride, 'config/update')
           const contextToggledOff = waf.createContext()
 
           const resultToggledOff = contextToggledOff.run(payload, TIMEOUT)
@@ -443,7 +435,7 @@ describe('DDWAF', () => {
             }
           }
 
-          const waf = new DDWAF(rules)
+          const waf = new DDWAF(rules, 'recommended')
           const monitorContext = waf.createContext()
 
           const resultMonitor = monitorContext.run(payload, TIMEOUT)
@@ -457,7 +449,7 @@ describe('DDWAF', () => {
             rules_override: testData.rulesOverride
           }
 
-          waf.update(updateWithRulesOverride)
+          waf.createOrUpdateConfig(updateWithRulesOverride, 'config/update')
           const blockContext = waf.createContext()
 
           const resultBlock = blockContext.run(payload, TIMEOUT)
@@ -477,7 +469,7 @@ describe('DDWAF', () => {
   })
 
   it('should support case_sensitive', () => {
-    const waf = new DDWAF(rules)
+    const waf = new DDWAF(rules, 'recommended')
     const context = waf.createContext()
 
     const result = context.run({
@@ -491,12 +483,12 @@ describe('DDWAF', () => {
   })
 
   it('should refuse invalid rule', () => {
-    assert.throws(() => new DDWAF({}), new Error('Invalid rules'))
-    assert.throws(() => new DDWAF(''), new TypeError('First argument must be an object'))
+    assert.throws(() => new DDWAF({}, 'empty_rules'), new Error('Invalid rules'))
+    assert.throws(() => new DDWAF('', 'non_object_rules'), new TypeError('First argument must be an object'))
   })
 
   it('should refuse to run with bad signatures', () => {
-    const waf = new DDWAF(rules)
+    const waf = new DDWAF(rules, 'recommended')
     const context = waf.createContext()
 
     const wronArgsError = new Error('Wrong number of arguments, 2 expected')
@@ -546,7 +538,7 @@ describe('DDWAF', () => {
       [function fn () {}, 'function fn () {}']
     ])
 
-    const waf = new DDWAF(rules)
+    const waf = new DDWAF(rules, 'recommended')
 
     for (const [key, expected] of possibleKeys) {
       const context = waf.createContext()
@@ -584,7 +576,7 @@ describe('DDWAF', () => {
       [function fn () {}, undefined]
     ])
 
-    const waf = new DDWAF(rules)
+    const waf = new DDWAF(rules, 'recommended')
 
     for (const [value, expected] of possibleValues) {
       const context = waf.createContext()
@@ -608,7 +600,7 @@ describe('DDWAF', () => {
   })
 
   it('should obfuscate keys', () => {
-    const waf = new DDWAF(rules, {
+    const waf = new DDWAF(rules, 'recommended', {
       obfuscatorKeyRegex: 'password'
     })
     const context = waf.createContext()
@@ -630,7 +622,7 @@ describe('DDWAF', () => {
   })
 
   it('should obfuscate values', () => {
-    const waf = new DDWAF(rules, {
+    const waf = new DDWAF(rules, 'recommended', {
       obfuscatorValueRegex: 'value_attack'
     })
     const context = waf.createContext()
@@ -650,13 +642,10 @@ describe('DDWAF', () => {
   })
 
   it('should collect derivatives information when a rule match', () => {
-    const waf = new DDWAF(processor)
+    const waf = new DDWAF(processor, 'processor_rules')
 
     const context = waf.createContext()
 
-    assert(waf.diagnostics.processors.addresses.optional.includes('server.request.query'))
-    assert(waf.diagnostics.processors.addresses.optional.includes('server.request.body'))
-    assert(waf.diagnostics.processors.addresses.required.includes('waf.context.processor'))
     assert(waf.diagnostics.processors.loaded.includes('processor-001'))
     assert.equal(waf.diagnostics.processors.failed.length, 0)
 
@@ -680,12 +669,9 @@ describe('DDWAF', () => {
   })
 
   it('should collect derivatives information when a rule does not match', () => {
-    const waf = new DDWAF(processor)
+    const waf = new DDWAF(processor, 'processor_rules')
     const context = waf.createContext()
 
-    assert(waf.diagnostics.processors.addresses.optional.includes('server.request.query'))
-    assert(waf.diagnostics.processors.addresses.optional.includes('server.request.body'))
-    assert(waf.diagnostics.processors.addresses.required.includes('waf.context.processor'))
     assert(waf.diagnostics.processors.loaded.includes('processor-001'))
     assert.equal(waf.diagnostics.processors.failed.length, 0)
 
@@ -708,12 +694,9 @@ describe('DDWAF', () => {
   })
 
   it('should collect all derivatives types', () => {
-    const waf = new DDWAF(processor)
+    const waf = new DDWAF(processor, 'processor_rules')
     const context = waf.createContext()
 
-    assert(waf.diagnostics.processors.addresses.optional.includes('server.request.query'))
-    assert(waf.diagnostics.processors.addresses.optional.includes('server.request.body'))
-    assert(waf.diagnostics.processors.addresses.required.includes('waf.context.processor'))
     assert(waf.diagnostics.processors.loaded.includes('processor-001'))
     assert.equal(waf.diagnostics.processors.failed.length, 0)
 
@@ -770,12 +753,9 @@ describe('DDWAF', () => {
   })
 
   it('should collect derivatives in two consecutive calls', () => {
-    const waf = new DDWAF(processor)
+    const waf = new DDWAF(processor, 'processor_rules')
     const context = waf.createContext()
 
-    assert(waf.diagnostics.processors.addresses.optional.includes('server.request.query'))
-    assert(waf.diagnostics.processors.addresses.optional.includes('server.request.body'))
-    assert(waf.diagnostics.processors.addresses.required.includes('waf.context.processor'))
     assert(waf.diagnostics.processors.loaded.includes('processor-001'))
     assert.equal(waf.diagnostics.processors.failed.length, 0)
 
@@ -815,7 +795,7 @@ describe('DDWAF', () => {
 
   describe('Action semantics', () => {
     it('should support action definition in initialisation', () => {
-      const waf = new DDWAF(rules)
+      const waf = new DDWAF(rules, 'recommended')
       const context = waf.createContext()
 
       const result = context.run({
@@ -838,7 +818,7 @@ describe('DDWAF', () => {
     })
 
     it('should support action definition in update', () => {
-      const waf = new DDWAF(rules)
+      const waf = new DDWAF(rules, 'recommended')
 
       const updatedRules = Object.assign({}, rules)
       updatedRules.actions = [{
@@ -851,7 +831,8 @@ describe('DDWAF', () => {
         }
       }]
 
-      waf.update(updatedRules)
+      waf.removeConfig('recommended')
+      waf.createOrUpdateConfig(updatedRules, 'recommended_action_modified')
 
       const context = waf.createContext()
       const resultWithUpdatedAction = context.run({
@@ -877,7 +858,7 @@ describe('DDWAF', () => {
 
 describe('limit tests', () => {
   it('should ignore elements too far in the objects', () => {
-    const waf = new DDWAF(rules)
+    const waf = new DDWAF(rules, 'recommended')
 
     const context1 = waf.createContext()
     const result1 = context1.run({
@@ -908,7 +889,7 @@ describe('limit tests', () => {
   })
 
   it('should match a moderately deeply nested object', () => {
-    const waf = new DDWAF(rules)
+    const waf = new DDWAF(rules, 'recommended')
     const context = waf.createContext()
 
     const result = context.run({
@@ -923,7 +904,7 @@ describe('limit tests', () => {
   })
 
   it('should set as invalid circular property dependency', () => {
-    const waf = new DDWAF(processor)
+    const waf = new DDWAF(processor, 'processor_rules')
     const context = waf.createContext()
     const payload = {
       key: 'value',
@@ -954,7 +935,7 @@ describe('limit tests', () => {
   })
 
   it('should set as invalid circular property dependency in deeper level', () => {
-    const waf = new DDWAF(processor)
+    const waf = new DDWAF(processor, 'processor_rules')
     const context = waf.createContext()
     const payload = {
       key: 'value',
@@ -985,7 +966,7 @@ describe('limit tests', () => {
   })
 
   it('should set as invalid circular array dependency', () => {
-    const waf = new DDWAF(processor)
+    const waf = new DDWAF(processor, 'processor_rules')
     const context = waf.createContext()
     const payload = []
     payload.push(payload, payload, payload)
@@ -1003,7 +984,7 @@ describe('limit tests', () => {
   })
 
   it('should set as invalid circular array dependency in deeper levels', () => {
-    const waf = new DDWAF(processor)
+    const waf = new DDWAF(processor, 'processor_rules')
     const context = waf.createContext()
     const payload = []
     payload.push({ payload })
@@ -1023,7 +1004,7 @@ describe('limit tests', () => {
   })
 
   it('should not set as invalid same instances in array', () => {
-    const waf = new DDWAF(processor)
+    const waf = new DDWAF(processor, 'processor_rules')
     const context = waf.createContext()
     const item = {
       key: 'value',
@@ -1048,7 +1029,7 @@ describe('limit tests', () => {
   })
 
   it('should not set as invalid same instance in different properties', () => {
-    const waf = new DDWAF(processor)
+    const waf = new DDWAF(processor, 'processor_rules')
     const context = waf.createContext()
     const prop = {
       key: 'value',
@@ -1079,7 +1060,7 @@ describe('limit tests', () => {
   })
 
   it('should not match an extremely deeply nested object', () => {
-    const waf = new DDWAF(rules)
+    const waf = new DDWAF(rules, 'recommended')
     const context = waf.createContext()
 
     const result = context.run({
@@ -1094,7 +1075,7 @@ describe('limit tests', () => {
   })
 
   it('should not limit the rules object', () => {
-    const waf = new DDWAF(rules)
+    const waf = new DDWAF(rules, 'recommended')
 
     // test first item in big rule
     const context1 = waf.createContext()
@@ -1118,7 +1099,7 @@ describe('limit tests', () => {
   })
 
   it('should use custom toJSON function', () => {
-    const waf = new DDWAF(rules)
+    const waf = new DDWAF(rules, 'recommended')
 
     const body = { a: 'not_an_attack' }
 
@@ -1148,7 +1129,7 @@ describe('limit tests', () => {
   })
 
   it('should use custom toJSON function in arrays', () => {
-    const waf = new DDWAF(rules)
+    const waf = new DDWAF(rules, 'recommended')
 
     const body = ['not_an_attack']
 
@@ -1193,7 +1174,7 @@ describe('limit tests', () => {
       }
     }
 
-    const waf = new DDWAF(processor)
+    const waf = new DDWAF(processor, 'processor_rules')
     const context = waf.createContext()
     const result = context.run({
       persistent: {
@@ -1236,7 +1217,7 @@ describe('limit tests', () => {
       }
     }
 
-    const waf = new DDWAF(processor)
+    const waf = new DDWAF(processor, 'processor_rules')
     const context = waf.createContext()
     const result = context.run({
       persistent: {
@@ -1281,7 +1262,7 @@ describe('limit tests', () => {
       }
     }
 
-    const waf = new DDWAF(processor)
+    const waf = new DDWAF(processor, 'processor_rules')
     const context = waf.createContext()
     const result = context.run({
       persistent: {
@@ -1313,7 +1294,7 @@ describe('limit tests', () => {
       c: 'c'
     }
 
-    const waf = new DDWAF(processor)
+    const waf = new DDWAF(processor, 'processor_rules')
     const context = waf.createContext()
     const result = context.run({
       persistent: {
@@ -1335,7 +1316,7 @@ describe('limit tests', () => {
   })
 
   it('should truncate string values exceeding maximum length', () => {
-    const waf = new DDWAF(rules)
+    const waf = new DDWAF(rules, 'recommended')
 
     const context1 = waf.createContext()
     const result1 = context1.run({
@@ -1362,7 +1343,7 @@ describe('limit tests', () => {
   })
 
   it('should handle multiple truncations in complex nested structure', () => {
-    const waf = new DDWAF(rules)
+    const waf = new DDWAF(rules, 'recommended')
 
     const longValue1 = 'a'.repeat(5000)
     const longValue2 = 'b'.repeat(6000)
@@ -1406,7 +1387,7 @@ describe('limit tests', () => {
 
 describe('Handle errors', () => {
   it('should handle invalid arguments number', () => {
-    const waf = new DDWAF(rules)
+    const waf = new DDWAF(rules, 'recommended')
     const context = waf.createContext()
 
     try {
@@ -1419,7 +1400,7 @@ describe('Handle errors', () => {
   })
 
   it('should handle invalid timeout arguments', () => {
-    const waf = new DDWAF(rules)
+    const waf = new DDWAF(rules, 'recommended')
     const context = waf.createContext()
 
     try {
@@ -1440,7 +1421,7 @@ describe('Handle errors', () => {
   })
 
   it('should handle invalid arguments', () => {
-    const waf = new DDWAF(rules)
+    const waf = new DDWAF(rules, 'recommended')
     const context = waf.createContext()
 
     try {

--- a/test/index.js
+++ b/test/index.js
@@ -151,145 +151,152 @@ describe('DDWAF', () => {
   })
 
   describe('WAF update', () => {
-    it('should throw an error when updating configuration on a disposed WAF instance', () => {
-      const waf = new DDWAF(rules, 'recommended')
-      waf.dispose()
-      assert.throws(
-        () => waf.createOrUpdateConfig(rules, 'config/update'),
-        new Error('Could not update a disposed WAF instance'))
-    })
 
-    it('should throw an error when updating configuration with no arguments', () => {
-      const waf = new DDWAF(rules, 'recommended')
-      assert.throws(() => waf.createOrUpdateConfig(), new Error('Wrong number of arguments, expected at least 2'))
-    })
+    describe('Update config', () => {
+      it('should throw an error when updating configuration on a disposed WAF instance', () => {
+        const waf = new DDWAF(rules, 'recommended')
+        waf.dispose()
+        assert.throws(
+          () => waf.createOrUpdateConfig(rules, 'config/update'),
+          new Error('Could not update a disposed WAF instance'))
+      })
 
-    it('should throw an error when updating configuration with just one argument', () => {
-      const waf = new DDWAF(rules, 'recommended')
-      assert.throws(() => waf.createOrUpdateConfig({}), new Error('Wrong number of arguments, expected at least 2'))
-    })
+      it('should throw an error when updating configuration with no arguments', () => {
+        const waf = new DDWAF(rules, 'recommended')
+        assert.throws(() => waf.createOrUpdateConfig(), new Error('Wrong number of arguments, expected at least 2'))
+      })
 
-    it('should throw a type error when updating configuration with invalid arguments', () => {
-      const waf = new DDWAF(rules, 'recommended')
-      assert.throws(
-        () => waf.createOrUpdateConfig('string', 'config/update'),
-        new TypeError('First argument must be an object')
-      )
-    })
+      it('should throw an error when updating configuration with just one argument', () => {
+        const waf = new DDWAF(rules, 'recommended')
+        assert.throws(() => waf.createOrUpdateConfig({}), new Error('Wrong number of arguments, expected at least 2'))
+      })
 
-    it('should return false when updating configuration with invalid configuration', () => {
-      const waf = new DDWAF(rules, 'recommended')
-      assert.strictEqual(waf.createOrUpdateConfig({}, 'config/update'), false)
-    })
+      it('should throw a type error when updating configuration with invalid arguments', () => {
+        const waf = new DDWAF(rules, 'recommended')
+        assert.throws(
+          () => waf.createOrUpdateConfig('string', 'config/update'),
+          new TypeError('First argument must be an object')
+        )
+      })
 
-    it('should return true when updating configuration', () => {
-      const waf = new DDWAF(rules, 'recommended')
-      const newConfig = {
-        version: '2.2',
-        metadata: {
-          rules_version: '1.3.0'
-        },
-        actions: [{
-          id: 'customredirect',
-          type: 'redirect_request',
-          parameters: {
-            status_code: '301',
-            location: '/'
-          }
-        }],
-        rules: [{
-          id: 'block_ip_original',
-          name: 'block ip',
-          tags: {
-            type: 'ip_addresses',
-            category: 'blocking'
+      it('should return false when updating configuration with invalid configuration', () => {
+        const waf = new DDWAF(rules, 'recommended')
+        assert.strictEqual(waf.createOrUpdateConfig({}, 'config/update'), false)
+      })
+
+      it('should return true when updating configuration', () => {
+        const waf = new DDWAF(rules, 'recommended')
+        const newConfig = {
+          version: '2.2',
+          metadata: {
+            rules_version: '1.3.0'
           },
-          conditions: [
-            {
-              parameters: {
-                inputs: [
-                  { address: 'http.client_ip' }
-                ],
-                data: 'blocked_ips'
-              },
-              operator: 'ip_match'
+          actions: [{
+            id: 'customredirect',
+            type: 'redirect_request',
+            parameters: {
+              status_code: '301',
+              location: '/'
             }
-          ],
-          transformers: [],
-          on_match: [
-            'customredirect'
-          ]
-        }]
-      }
-      assert.strictEqual(waf.createOrUpdateConfig(newConfig, 'config/update'), true)
+          }],
+          rules: [{
+            id: 'block_ip_original',
+            name: 'block ip',
+            tags: {
+              type: 'ip_addresses',
+              category: 'blocking'
+            },
+            conditions: [
+              {
+                parameters: {
+                  inputs: [
+                    { address: 'http.client_ip' }
+                  ],
+                  data: 'blocked_ips'
+                },
+                operator: 'ip_match'
+              }
+            ],
+            transformers: [],
+            on_match: [
+              'customredirect'
+            ]
+          }]
+        }
+        assert.strictEqual(waf.createOrUpdateConfig(newConfig, 'config/update'), true)
+      })
     })
 
-    it('should throw an error when removing a configuration on a disposed WAF instance', () => {
-      const waf = new DDWAF(rules, 'recommended')
-      waf.dispose()
-      assert.throws(
-        () => waf.removeConfig('config/update'),
-        new Error('Could not update a disposed WAF instance'))
+    describe('Remove config', () => {
+      it('should throw an error when removing a configuration on a disposed WAF instance', () => {
+        const waf = new DDWAF(rules, 'recommended')
+        waf.dispose()
+        assert.throws(
+          () => waf.removeConfig('config/update'),
+          new Error('Could not update a disposed WAF instance'))
+      })
+
+      it('should throw an error when removing a configuration with no arguments', () => {
+        const waf = new DDWAF(rules, 'recommended')
+        assert.throws(() => waf.removeConfig(), new Error('Wrong number of arguments, expected at least 1'))
+      })
+
+      it('should throw a type error when removing a configuration with invalid arguments', () => {
+        const waf = new DDWAF(rules, 'recommended')
+        assert.throws(
+          () => waf.removeConfig(null),
+          new TypeError('First argument must be a string')
+        )
+      })
+
+      it('should return true when removing an existing configuration', () => {
+        const waf = new DDWAF(rules, 'recommended')
+        assert.strictEqual(waf.removeConfig('recommended'), true)
+      })
+
+      it('should return false when removing a non-existing configuration', () => {
+        const waf = new DDWAF(rules, 'recommended')
+        assert.strictEqual(waf.removeConfig('config/update'), false)
+      })
     })
 
-    it('should throw an error when removing a configuration with no arguments', () => {
-      const waf = new DDWAF(rules, 'recommended')
-      assert.throws(() => waf.removeConfig(), new Error('Wrong number of arguments, expected at least 1'))
-    })
+    describe('Config paths', () => {
+      it('should have no loaded configuration paths on WAF disposed instance', () => {
+        const waf = new DDWAF(rules, 'recommended')
+        waf.dispose()
+        assert.strictEqual(waf.configPaths.length, 0)
+      })
 
-    it('should throw a type error when removing a configuration with invalid arguments', () => {
-      const waf = new DDWAF(rules, 'recommended')
-      assert.throws(
-        () => waf.removeConfig(null),
-        new TypeError('First argument must be a string')
-      )
-    })
-
-    it('should return true when removing an existing configuration', () => {
-      const waf = new DDWAF(rules, 'recommended')
-      assert.strictEqual(waf.removeConfig('recommended'), true)
-    })
-
-    it('should return false when removing a non-existing configuration', () => {
-      const waf = new DDWAF(rules, 'recommended')
-      assert.strictEqual(waf.removeConfig('config/update'), false)
-    })
-
-    it('should have no loaded configuration paths on WAF disposed instance', () => {
-      const waf = new DDWAF(rules, 'recommended')
-      waf.dispose()
-      assert.strictEqual(waf.configPaths.length, 0)
-    })
-
-    it('should have loaded configuration paths', () => {
-      const waf = new DDWAF(rules, 'recommended')
-      const newConfig = {
-        rules: [{
-          id: 'block_ip_original',
-          name: 'block ip',
-          tags: {
-            type: 'ip_addresses',
-            category: 'blocking'
-          },
-          conditions: [
-            {
-              parameters: {
-                inputs: [
-                  { address: 'http.client_ip' }
-                ],
-                data: 'blocked_ips'
-              },
-              operator: 'ip_match'
-            }
-          ],
-          transformers: [],
-          on_match: [
-            'customredirect'
-          ]
-        }]
-      }
-      waf.createOrUpdateConfig(newConfig, 'config/update')
-      assert.deepStrictEqual(['config/update', 'recommended'], waf.configPaths)
+      it('should have loaded configuration paths', () => {
+        const waf = new DDWAF(rules, 'recommended')
+        const newConfig = {
+          rules: [{
+            id: 'block_ip_original',
+            name: 'block ip',
+            tags: {
+              type: 'ip_addresses',
+              category: 'blocking'
+            },
+            conditions: [
+              {
+                parameters: {
+                  inputs: [
+                    { address: 'http.client_ip' }
+                  ],
+                  data: 'blocked_ips'
+                },
+                operator: 'ip_match'
+              }
+            ],
+            transformers: [],
+            on_match: [
+              'customredirect'
+            ]
+          }]
+        }
+        waf.createOrUpdateConfig(newConfig, 'config/update')
+        assert.deepStrictEqual(['config/update', 'recommended'], waf.configPaths)
+      })
     })
 
     it('should update diagnostics, knownAddresses, and knownActions when updating an instance with new ruleSet', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -255,6 +255,43 @@ describe('DDWAF', () => {
       assert.strictEqual(waf.removeConfig('config/update'), false)
     })
 
+    it('should have no loaded configuration paths on WAF disposed instance', () => {
+      const waf = new DDWAF(rules, 'recommended')
+      waf.dispose()
+      assert.strictEqual(waf.configPaths.length, 0)
+    })
+
+    it('should have loaded configuration paths', () => {
+      const waf = new DDWAF(rules, 'recommended')
+      const newConfig = {
+        rules: [{
+          id: 'block_ip_original',
+          name: 'block ip',
+          tags: {
+            type: 'ip_addresses',
+            category: 'blocking'
+          },
+          conditions: [
+            {
+              parameters: {
+                inputs: [
+                  { address: 'http.client_ip' }
+                ],
+                data: 'blocked_ips'
+              },
+              operator: 'ip_match'
+            }
+          ],
+          transformers: [],
+          on_match: [
+            'customredirect'
+          ]
+        }]
+      }
+      waf.createOrUpdateConfig(newConfig, 'config/update')
+      assert.deepStrictEqual(['config/update', 'recommended'], waf.configPaths)
+    })
+
     it('should update diagnostics, knownAddresses, and knownActions when updating an instance with new ruleSet', () => {
       const waf = new DDWAF({
         version: '2.2',


### PR DESCRIPTION
### What does this PR do?

- Update `libddwaf` to v1.24.1
- Implements WAF builder API

### Motivation

`libddwaf` changed its interface in v1.23.0 with breaking changes in order to move the configuration update management from the tracer to the library.

### Additional Notes

[Upgrading guide](https://github.com/DataDog/libddwaf/blob/master/UPGRADING.md#upgrading-from-1220-to-1230)


