### PR TITLE
Fix libddwaf lib download

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 
 env:
-  GH_TOKEN: ${{ secrets.GH_TOKEN }}
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   download-libddwaf:

--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -20,7 +20,7 @@ const libddwafFolder = path.join(__dirname, '..', 'libddwaf')
 
 fs.mkdirSync(libddwafFolder, { recursive: true })
 
-childProcess.spawnSync('gh', [
+const res = childProcess.spawnSync('gh', [
   'release', 'download',
   '--repo', 'DataDog/libddwaf',
   '--dir', libddwafFolder,
@@ -29,6 +29,8 @@ childProcess.spawnSync('gh', [
   '--pattern', `libddwaf-${libddwafVersion}-windows-*.tar.gz`,
   libddwafVersion
 ])
+
+console.log(res.stderr.toString())
 
 for (const name of fs.readdirSync(libddwafFolder)) {
   const file = path.join(libddwafFolder, name)

--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -20,7 +20,7 @@ const libddwafFolder = path.join(__dirname, '..', 'libddwaf')
 
 fs.mkdirSync(libddwafFolder, { recursive: true })
 
-const res = childProcess.spawnSync('gh', [
+childProcess.spawnSync('gh', [
   'release', 'download',
   '--repo', 'DataDog/libddwaf',
   '--dir', libddwafFolder,
@@ -29,8 +29,6 @@ const res = childProcess.spawnSync('gh', [
   '--pattern', `libddwaf-${libddwafVersion}-windows-*.tar.gz`,
   libddwafVersion
 ])
-
-console.log(res.stderr.toString())
 
 for (const name of fs.readdirSync(libddwafFolder)) {
   const file = path.join(libddwafFolder, name)


### PR DESCRIPTION
### What does this PR do?

Use the automatically created token from GitHub Actions to download `libddwaf` lib from its repo.