### PR TITLE
v9.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/native-appsec",
-  "version": "8.5.2",
+  "version": "9.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/native-appsec",
-  "version": "8.5.2",
+  "version": "9.0.0",
   "description": "Node.js bindings for libddwaf",
   "main": "index.js",
   "libddwaf_version": "1.24.1",


### PR DESCRIPTION
### What does this PR do?

Bump package version to `v9.0.0`

### Motivation

New `libddwaf` builder interface

### Additional Notes

Second take after [messing with release GH action](https://github.com/DataDog/dd-native-appsec-js/pull/141)