### PR TITLE
Update`libddwaf` to v1.26.0

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -37,6 +37,7 @@ type result = {
   derivatives?: object;
   metrics?: TruncationMetrics;
   errorCode?: number;
+  keep?: boolean;
 }
 
 type payload = {

--- a/index.d.ts
+++ b/index.d.ts
@@ -30,11 +30,11 @@ type TruncationMetrics = {
 
 type result = {
   timeout: boolean;
-  totalRuntime?: number;
+  duration?: number;
   events?: object[]; // https://github.com/DataDog/libddwaf/blob/master/schema/events.json
   status?: 'match'; // TODO: remove this if new statuses are never added
   actions?: object[];
-  derivatives?: object;
+  attributes?: object;
   metrics?: TruncationMetrics;
   errorCode?: number;
   keep?: boolean;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "9.0.0",
   "description": "Node.js bindings for libddwaf",
   "main": "index.js",
-  "libddwaf_version": "1.24.1",
+  "libddwaf_version": "1.26.0",
   "scripts": {
     "install": "exit 0",
     "rebuild": "node-gyp rebuild",

--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -244,7 +244,7 @@ ddwaf_object* to_ddwaf_object(
   return ddwaf_object_invalid(object);
 }
 
-Napi::Value from_ddwaf_object(ddwaf_object *object, Napi::Env env) {
+Napi::Value from_ddwaf_object(const ddwaf_object *object, Napi::Env env) {
   DDWAF_OBJ_TYPE type = object->type;
 
   Napi::Value result;
@@ -268,7 +268,7 @@ Napi::Value from_ddwaf_object(ddwaf_object *object, Napi::Env env) {
       }
 
       for (uint32_t i = 0; i < object->nbEntries; ++i) {
-        ddwaf_object* e = &object->array[i];
+        const ddwaf_object* e = &object->array[i];
         Napi::Value v = from_ddwaf_object(e, env);
         arr[i] = v;
       }
@@ -280,7 +280,7 @@ Napi::Value from_ddwaf_object(ddwaf_object *object, Napi::Env env) {
       Napi::Object obj = Napi::Object::New(env);
 
       for (uint32_t i = 0; i < object->nbEntries; ++i) {
-        ddwaf_object* e = &object->array[i];
+        const ddwaf_object* e = &object->array[i];
         Napi::String k = Napi::String::New(env, e->parameterName, e->parameterNameLength);
         if (env.IsExceptionPending()) {
           mlog("Exception pending");

--- a/src/convert.h
+++ b/src/convert.h
@@ -21,6 +21,6 @@ ddwaf_object* to_ddwaf_object(
   WAFTruncationMetrics *metrics
 );
 
-Napi::Value from_ddwaf_object(ddwaf_object *object, Napi::Env env);
+Napi::Value from_ddwaf_object(const ddwaf_object *object, Napi::Env env);
 
 #endif  // SRC_CONVERT_H_

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,6 +15,13 @@
 #include "src/log.h"
 #include "src/convert.h"
 
+// libddwaf result field name constants
+constexpr size_t EVENTS_LEN = 6;
+constexpr size_t ACTIONS_LEN = 7;
+constexpr size_t ATTRIBUTES_LEN = 10;
+constexpr size_t KEEP_LEN = 4;
+constexpr size_t DURATION_LEN = 8;
+constexpr size_t TIMEOUT_LEN = 7;
 
 Napi::Object DDWAF::Init(Napi::Env env, Napi::Object exports) {
   mlog("Setting up class DDWAF");
@@ -457,13 +464,6 @@ Napi::Value DDWAFContext::run(const Napi::CallbackInfo& info) {
   }
 
   // No error. Collect result data and return
-
-  constexpr size_t EVENTS_LEN = 6;
-  constexpr size_t ACTIONS_LEN = 7;
-  constexpr size_t ATTRIBUTES_LEN = 10;
-  constexpr size_t KEEP_LEN = 4;
-  constexpr size_t DURATION_LEN = 8;
-  constexpr size_t TIMEOUT_LEN = 7;
 
   const ddwaf_object *events = nullptr, *actions = nullptr, *attributes = nullptr,
                      *keep = nullptr, *duration = nullptr, *run_timeout = nullptr;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -457,7 +457,13 @@ Napi::Value DDWAFContext::run(const Napi::CallbackInfo& info) {
   }
   // there is no error. We need to collect perf data
 
-  // Extract all relevant objects efficiently using a loop
+  constexpr size_t EVENTS_LEN = 6;
+  constexpr size_t ACTIONS_LEN = 7;
+  constexpr size_t ATTRIBUTES_LEN = 10;
+  constexpr size_t KEEP_LEN = 4;
+  constexpr size_t DURATION_LEN = 8;
+  constexpr size_t TIMEOUT_LEN = 7;
+
   const ddwaf_object *events = nullptr, *actions = nullptr, *attributes = nullptr,
                      *keep = nullptr, *duration = nullptr, *run_timeout = nullptr;
 
@@ -475,17 +481,17 @@ Napi::Value DDWAFContext::run(const Napi::CallbackInfo& info) {
       continue;
     }
 
-    if (length == (sizeof("events") - 1) && memcmp(key, "events", length) == 0) {
+    if (length == EVENTS_LEN && memcmp(key, "events", EVENTS_LEN) == 0) {
       events = child;
-    } else if (length == (sizeof("actions") - 1) && memcmp(key, "actions", length) == 0) {
+    } else if (length == ACTIONS_LEN && memcmp(key, "actions", ACTIONS_LEN) == 0) {
       actions = child;
-    } else if (length == (sizeof("attributes") - 1) && memcmp(key, "attributes", length) == 0) {
+    } else if (length == ATTRIBUTES_LEN && memcmp(key, "attributes", ATTRIBUTES_LEN) == 0) {
       attributes = child;
-    } else if (length == (sizeof("keep") - 1) && memcmp(key, "keep", length) == 0) {
+    } else if (length == KEEP_LEN && memcmp(key, "keep", KEEP_LEN) == 0) {
       keep = child;
-    } else if (length == (sizeof("duration") - 1) && memcmp(key, "duration", length) == 0) {
+    } else if (length == DURATION_LEN && memcmp(key, "duration", DURATION_LEN) == 0) {
       duration = child;
-    } else if (length == (sizeof("timeout") - 1) && memcmp(key, "timeout", length) == 0) {
+    } else if (length == TIMEOUT_LEN && memcmp(key, "timeout", TIMEOUT_LEN) == 0) {
       run_timeout = child;
     }
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -455,7 +455,8 @@ Napi::Value DDWAFContext::run(const Napi::CallbackInfo& info) {
     default:
       break;
   }
-  // there is no error. We need to collect perf data
+
+  // No error. Collect result data and return
 
   constexpr size_t EVENTS_LEN = 6;
   constexpr size_t ACTIONS_LEN = 7;
@@ -496,7 +497,6 @@ Napi::Value DDWAFContext::run(const Napi::CallbackInfo& info) {
     }
   }
 
-  // Now use the extracted objects
   mlog("Set timeout");
   if (run_timeout && run_timeout->type == DDWAF_OBJ_BOOL) {
     res.Set("timeout", Napi::Boolean::New(env, run_timeout->boolean));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -497,25 +497,32 @@ Napi::Value DDWAFContext::run(const Napi::CallbackInfo& info) {
   }
 
   if (duration && duration->type == DDWAF_OBJ_UNSIGNED && duration->uintValue > 0) {
-    mlog("Set total_runtime");
-    res.Set("totalRuntime", Napi::Number::New(env, duration->uintValue));
+    mlog("Set duration");
+    res.Set("duration", Napi::Number::New(env, duration->uintValue));
   }
 
   if (attributes && ddwaf_object_size(attributes) > 0) {
-    res.Set("derivatives", from_ddwaf_object(const_cast<ddwaf_object*>(attributes), env));
+    mlog("Set attributes");
+    res.Set("attributes", from_ddwaf_object(const_cast<ddwaf_object*>(attributes), env));
   }
 
   if (code == DDWAF_MATCH) {
+    mlog("ddwaf result is a match")
     res.Set("status", Napi::String::New(env, "match"));
+
     if (events) {
+      mlog("Set events")
       res.Set("events", from_ddwaf_object(const_cast<ddwaf_object*>(events), env));
     }
+
     if (actions) {
+      mlog("Set actions")
       res.Set("actions", from_ddwaf_object(const_cast<ddwaf_object*>(actions), env));
     }
   }
 
   if (keep && keep->type == DDWAF_OBJ_BOOL) {
+    mlog("Set keep")
     res.Set("keep", Napi::Boolean::New(env, keep->boolean));
   }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -503,7 +503,7 @@ Napi::Value DDWAFContext::run(const Napi::CallbackInfo& info) {
 
   if (attributes && ddwaf_object_size(attributes) > 0) {
     mlog("Set attributes");
-    res.Set("attributes", from_ddwaf_object(const_cast<ddwaf_object*>(attributes), env));
+    res.Set("attributes", from_ddwaf_object(attributes, env));
   }
 
   if (code == DDWAF_MATCH) {
@@ -512,12 +512,12 @@ Napi::Value DDWAFContext::run(const Napi::CallbackInfo& info) {
 
     if (events) {
       mlog("Set events")
-      res.Set("events", from_ddwaf_object(const_cast<ddwaf_object*>(events), env));
+      res.Set("events", from_ddwaf_object(events, env));
     }
 
     if (actions) {
       mlog("Set actions")
-      res.Set("actions", from_ddwaf_object(const_cast<ddwaf_object*>(actions), env));
+      res.Set("actions", from_ddwaf_object(actions, env));
     }
   }
 

--- a/test/index.js
+++ b/test/index.js
@@ -939,6 +939,35 @@ describe('DDWAF', () => {
     assert(waf.disposed)
   })
 
+  it('should include keep field in result object', () => {
+    const waf = new DDWAF(rules, 'recommended')
+    const context = waf.createContext()
+
+    // Non-match result
+    let result = context.run({
+      persistent: {
+        'server.request.headers.no_cookies': 'normal_value'
+      }
+    }, TIMEOUT)
+
+    assert.strictEqual(result.timeout, false)
+    assert.strictEqual(typeof result.keep, 'boolean')
+
+    // Match result
+    result = context.run({
+      persistent: {
+        'server.request.headers.no_cookies': 'value_attack'
+      }
+    }, TIMEOUT)
+
+    assert.strictEqual(result.timeout, false)
+    assert.strictEqual(result.status, 'match')
+    assert.strictEqual(typeof result.keep, 'boolean')
+
+    context.dispose()
+    waf.dispose()
+  })
+
   describe('Action semantics', () => {
     it('should support action definition in initialisation', () => {
       const waf = new DDWAF(rules, 'recommended')

--- a/test/index.js
+++ b/test/index.js
@@ -787,7 +787,7 @@ describe('DDWAF', () => {
     assert.strictEqual(result.events[0].rule_matches[0].parameters[0].highlight[0], '<Redacted>')
   })
 
-  it('should collect derivatives information when a rule match', () => {
+  it('should collect result attributes information when a rule match', () => {
     const waf = new DDWAF(processor, 'processor_rules')
 
     const context = waf.createContext()
@@ -805,7 +805,7 @@ describe('DDWAF', () => {
     }, TIMEOUT)
 
     assert.strictEqual(result.status, 'match')
-    assert.deepStrictEqual(result.derivatives, { 'server.request.body.schema': [8] })
+    assert.deepStrictEqual(result.attributes, { 'server.request.body.schema': [8] })
 
     context.dispose()
     assert(context.disposed)
@@ -814,7 +814,7 @@ describe('DDWAF', () => {
     assert(waf.disposed)
   })
 
-  it('should collect derivatives information when a rule does not match', () => {
+  it('should collect result attributes information when a rule does not match', () => {
     const waf = new DDWAF(processor, 'processor_rules')
     const context = waf.createContext()
 
@@ -830,7 +830,7 @@ describe('DDWAF', () => {
       }
     }, TIMEOUT)
 
-    assert.deepStrictEqual(result.derivatives, { 'server.request.body.schema': [8] })
+    assert.deepStrictEqual(result.attributes, { 'server.request.body.schema': [8] })
 
     context.dispose()
     assert(context.disposed)
@@ -839,7 +839,7 @@ describe('DDWAF', () => {
     assert(waf.disposed)
   })
 
-  it('should collect all derivatives types', () => {
+  it('should collect all result attributes types', () => {
     const waf = new DDWAF(processor, 'processor_rules')
     const context = waf.createContext()
 
@@ -870,7 +870,7 @@ describe('DDWAF', () => {
       }
     }, TIMEOUT)
 
-    assert.deepStrictEqual(result.derivatives, {
+    assert.deepStrictEqual(result.attributes, {
       'server.request.body.schema': [
         {
           null: [1],
@@ -898,7 +898,7 @@ describe('DDWAF', () => {
     assert(waf.disposed)
   })
 
-  it('should collect derivatives in two consecutive calls', () => {
+  it('should collect result attributes in two consecutive calls', () => {
     const waf = new DDWAF(processor, 'processor_rules')
     const context = waf.createContext()
 
@@ -911,7 +911,7 @@ describe('DDWAF', () => {
       }
     }, TIMEOUT)
 
-    assert.strictEqual(result.derivatives, undefined)
+    assert.strictEqual(result.attributes, undefined)
 
     result = context.run({
       persistent: {
@@ -922,7 +922,7 @@ describe('DDWAF', () => {
       }
     }, TIMEOUT)
 
-    assert.deepStrictEqual(result.derivatives, { 'server.request.body.schema': [8] })
+    assert.deepStrictEqual(result.attributes, { 'server.request.body.schema': [8] })
 
     result = context.run({
       persistent: {
@@ -930,7 +930,7 @@ describe('DDWAF', () => {
       }
     }, TIMEOUT)
 
-    assert.deepStrictEqual(result.derivatives, { 'server.request.query.schema': [8] })
+    assert.deepStrictEqual(result.attributes, { 'server.request.query.schema': [8] })
 
     context.dispose()
     assert(context.disposed)
@@ -1067,7 +1067,7 @@ describe('limit tests', () => {
       }
     }, TIMEOUT)
 
-    assert.deepStrictEqual(result.derivatives, {
+    assert.deepStrictEqual(result.attributes, {
       'server.request.body.schema': [
         {
           mail: [8],
@@ -1098,7 +1098,7 @@ describe('limit tests', () => {
       }
     }, TIMEOUT)
 
-    assert.deepStrictEqual(result.derivatives, {
+    assert.deepStrictEqual(result.attributes, {
       'server.request.body.schema': [
         {
           mail: [8],
@@ -1124,7 +1124,7 @@ describe('limit tests', () => {
       }
     }, TIMEOUT)
 
-    assert.deepStrictEqual(result.derivatives, {
+    assert.deepStrictEqual(result.attributes, {
       'server.request.body.schema': [[[0]], { len: 3 }]
     })
   })
@@ -1144,7 +1144,7 @@ describe('limit tests', () => {
       }
     }, TIMEOUT)
 
-    assert.deepStrictEqual(result.derivatives, {
+    assert.deepStrictEqual(result.attributes, {
       'server.request.body.schema': [[[{ payload: [0] }]], { len: 3 }]
     })
   })
@@ -1166,7 +1166,7 @@ describe('limit tests', () => {
       }
     }, TIMEOUT)
 
-    assert.deepStrictEqual(result.derivatives, {
+    assert.deepStrictEqual(result.attributes, {
       'server.request.body.schema': [
         [[{ mail: [8], key: [8] }]],
         { len: 4 }
@@ -1194,7 +1194,7 @@ describe('limit tests', () => {
       }
     }, TIMEOUT)
 
-    assert.deepStrictEqual(result.derivatives, {
+    assert.deepStrictEqual(result.attributes, {
       'server.request.body.schema': [
         {
           prop1: [{ mail: [8], key: [8] }],
@@ -1331,7 +1331,7 @@ describe('limit tests', () => {
       }
     }, TIMEOUT)
 
-    assert.deepStrictEqual(result.derivatives, {
+    assert.deepStrictEqual(result.attributes, {
       'server.request.body.schema': [
         [
           [
@@ -1374,7 +1374,7 @@ describe('limit tests', () => {
       }
     }, TIMEOUT)
 
-    assert.deepStrictEqual(result.derivatives, {
+    assert.deepStrictEqual(result.attributes, {
       'server.request.body.schema': [
         {
           c: [8],
@@ -1419,7 +1419,7 @@ describe('limit tests', () => {
       }
     }, TIMEOUT)
 
-    assert.deepStrictEqual(result.derivatives, {
+    assert.deepStrictEqual(result.attributes, {
       'server.request.body.schema': [
         {
           a: [16],
@@ -1451,7 +1451,7 @@ describe('limit tests', () => {
       }
     }, TIMEOUT)
 
-    assert.deepStrictEqual(result.derivatives, {
+    assert.deepStrictEqual(result.attributes, {
       'server.request.body.schema': [
         {
           a: [0],

--- a/test/index.js
+++ b/test/index.js
@@ -952,6 +952,7 @@ describe('DDWAF', () => {
 
     assert.strictEqual(result.timeout, false)
     assert.strictEqual(typeof result.keep, 'boolean')
+    assert.strictEqual(result.keep, false)
 
     // Match result
     result = context.run({
@@ -963,6 +964,7 @@ describe('DDWAF', () => {
     assert.strictEqual(result.timeout, false)
     assert.strictEqual(result.status, 'match')
     assert.strictEqual(typeof result.keep, 'boolean')
+    assert.strictEqual(result.keep, true)
 
     context.dispose()
     waf.dispose()


### PR DESCRIPTION
### What does this PR do?

- Update `libddwaf` to v1.26.0 from v1.24.1
- Implements new `ddwaf_run` result
- Changes some result properties names in JS result object:
  - `derviatives` for `attributes`
  - `totalRuntime` for `duration`
- New result property `keep`

### Motivation

`libddwaf` v1.25.0 removes `ddwaf_result` structure, which has been replaced by a `ddwaf_object`, with some changes in its structure.

### Additional Notes

[Upgrading guide](https://github.com/DataDog/libddwaf/blob/master/UPGRADING.md)

[APPSEC-57562](https://datadoghq.atlassian.net/browse/APPSEC-57562)


[APPSEC-57562]: https://datadoghq.atlassian.net/browse/APPSEC-57562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ