### PR TITLE
Add support for all ddwaf_object types in `from_ddwaf_object`

### DIFF
--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -250,11 +250,20 @@ Napi::Value from_ddwaf_object(const ddwaf_object *object, Napi::Env env) {
   Napi::Value result;
 
   switch (type) {
+    case DDWAF_OBJ_NULL:
+      result = env.Null();
+      break;
+    case DDWAF_OBJ_BOOL:
+      result = Napi::Boolean::New(env, object->boolean);
+      break;
     case DDWAF_OBJ_SIGNED:
       result = Napi::Number::New(env, object->intValue);
       break;
     case DDWAF_OBJ_UNSIGNED:
       result = Napi::Number::New(env, object->uintValue);
+      break;
+    case DDWAF_OBJ_FLOAT:
+      result = Napi::Number::New(env, object->f64);
       break;
     case DDWAF_OBJ_STRING:
       result = Napi::String::New(env, object->stringValue, object->nbEntries);

--- a/test/index.js
+++ b/test/index.js
@@ -42,7 +42,8 @@ describe('DDWAF', () => {
           'value_matchall',
           'key_matchall',
           'custom_action_rule',
-          'long_rule'
+          'long_rule',
+          'test-marshalling'
         ],
         skipped: [],
         failed: ['invalid_1', 'invalid_2', 'invalid_3'],
@@ -417,7 +418,8 @@ describe('DDWAF', () => {
             'value_matchall',
             'key_matchall',
             'custom_action_rule',
-            'long_rule'
+            'long_rule',
+            'test-marshalling'
           ],
           failed: ['invalid_1', 'invalid_2', 'invalid_3'],
           skipped: [],
@@ -965,6 +967,36 @@ describe('DDWAF', () => {
     assert.strictEqual(result.status, 'match')
     assert.strictEqual(typeof result.keep, 'boolean')
     assert.strictEqual(result.keep, true)
+
+    context.dispose()
+    waf.dispose()
+  })
+
+  it('should perform correct marshalling of ddwaf_object', () => {
+    const waf = new DDWAF(rules, 'recommended')
+    const context = waf.createContext()
+    const result = context.run({
+      persistent: {
+        'server.request.headers.no_cookies': 'marshalling'
+      }
+    }, TIMEOUT)
+
+    assert.strictEqual(result.timeout, false)
+    assert.strictEqual(result.status, 'match')
+    assert.strictEqual(typeof result.keep, 'boolean')
+    assert.strictEqual(result.keep, true)
+    assert.strictEqual(typeof result.attributes['_dd.appsec.trace.integer'], 'number')
+    assert.strictEqual(result.attributes['_dd.appsec.trace.integer'], 662607015)
+    assert.strictEqual(typeof result.attributes['_dd.appsec.trace.negative_integer'], 'number')
+    assert.strictEqual(result.attributes['_dd.appsec.trace.negative_integer'], -662607015)
+    assert.strictEqual(typeof result.attributes['_dd.appsec.trace.float'], 'number')
+    assert.strictEqual(result.attributes['_dd.appsec.trace.float'], 2.71828)
+    assert.strictEqual(typeof result.attributes['_dd.appsec.trace.negative_float'], 'number')
+    assert.strictEqual(result.attributes['_dd.appsec.trace.negative_float'], -3.14159)
+    assert.strictEqual(typeof result.attributes['_dd.appsec.trace.bool'], 'boolean')
+    assert.strictEqual(result.attributes['_dd.appsec.trace.bool'], true)
+    assert.strictEqual(typeof result.attributes['_dd.appsec.trace.string'], 'string')
+    assert.strictEqual(result.attributes['_dd.appsec.trace.string'], 'Gott ist tot')
 
     context.dispose()
     waf.dispose()

--- a/test/index.js
+++ b/test/index.js
@@ -42,8 +42,8 @@ describe('DDWAF', () => {
           'value_matchall',
           'key_matchall',
           'custom_action_rule',
-          'long_rule',
-          'test-marshalling'
+          'test-marshalling',
+          'long_rule'
         ],
         skipped: [],
         failed: ['invalid_1', 'invalid_2', 'invalid_3'],
@@ -418,8 +418,8 @@ describe('DDWAF', () => {
             'value_matchall',
             'key_matchall',
             'custom_action_rule',
-            'long_rule',
-            'test-marshalling'
+            'test-marshalling',
+            'long_rule'
           ],
           failed: ['invalid_1', 'invalid_2', 'invalid_3'],
           skipped: [],
@@ -985,18 +985,15 @@ describe('DDWAF', () => {
     assert.strictEqual(result.status, 'match')
     assert.strictEqual(typeof result.keep, 'boolean')
     assert.strictEqual(result.keep, true)
-    assert.strictEqual(typeof result.attributes['_dd.appsec.trace.integer'], 'number')
     assert.strictEqual(result.attributes['_dd.appsec.trace.integer'], 662607015)
-    assert.strictEqual(typeof result.attributes['_dd.appsec.trace.negative_integer'], 'number')
     assert.strictEqual(result.attributes['_dd.appsec.trace.negative_integer'], -662607015)
-    assert.strictEqual(typeof result.attributes['_dd.appsec.trace.float'], 'number')
     assert.strictEqual(result.attributes['_dd.appsec.trace.float'], 2.71828)
-    assert.strictEqual(typeof result.attributes['_dd.appsec.trace.negative_float'], 'number')
     assert.strictEqual(result.attributes['_dd.appsec.trace.negative_float'], -3.14159)
-    assert.strictEqual(typeof result.attributes['_dd.appsec.trace.bool'], 'boolean')
     assert.strictEqual(result.attributes['_dd.appsec.trace.bool'], true)
-    assert.strictEqual(typeof result.attributes['_dd.appsec.trace.string'], 'string')
-    assert.strictEqual(result.attributes['_dd.appsec.trace.string'], 'Lorem ipsum sit amet')
+    assert.strictEqual(
+      result.attributes['_dd.appsec.trace.string'],
+      'It was a bright cold day in April, and the clocks were striking thirteen.'
+    )
 
     context.dispose()
     waf.dispose()

--- a/test/index.js
+++ b/test/index.js
@@ -996,7 +996,7 @@ describe('DDWAF', () => {
     assert.strictEqual(typeof result.attributes['_dd.appsec.trace.bool'], 'boolean')
     assert.strictEqual(result.attributes['_dd.appsec.trace.bool'], true)
     assert.strictEqual(typeof result.attributes['_dd.appsec.trace.string'], 'string')
-    assert.strictEqual(result.attributes['_dd.appsec.trace.string'], 'Gott ist tot')
+    assert.strictEqual(result.attributes['_dd.appsec.trace.string'], 'Lorem ipsum sit amet')
 
     context.dispose()
     waf.dispose()

--- a/test/index.js
+++ b/test/index.js
@@ -983,7 +983,6 @@ describe('DDWAF', () => {
 
     assert.strictEqual(result.timeout, false)
     assert.strictEqual(result.status, 'match')
-    assert.strictEqual(typeof result.keep, 'boolean')
     assert.strictEqual(result.keep, true)
     assert.strictEqual(result.attributes['_dd.appsec.trace.integer'], 662607015)
     assert.strictEqual(result.attributes['_dd.appsec.trace.negative_integer'], -662607015)

--- a/test/rules.json
+++ b/test/rules.json
@@ -1339,6 +1339,54 @@
       "transformers": [
         "lowercase"
       ]
+    },
+    {
+      "id": "test-marshalling",
+      "name": "Test ddwaf_object marshalling",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies"
+              }
+            ],
+            "list": [
+              "marshalling"
+            ]
+          },
+          "operator": "phrase_match"
+        }
+      ],
+      "output": {
+        "event": false,
+        "keep": true,
+        "attributes": {
+          "_dd.appsec.trace.string": {
+            "value": "Gott ist tot"
+          },
+          "_dd.appsec.trace.integer": {
+            "value": 662607015
+          },
+          "_dd.appsec.trace.negative_integer": {
+            "value": -662607015
+          },
+          "_dd.appsec.trace.float": {
+            "value": 2.71828
+          },
+          "_dd.appsec.trace.negative_float": {
+            "value": -3.14159
+          },
+          "_dd.appsec.trace.bool": {
+            "value": true
+          }
+        }
+      },
+      "on_match": []
     }
   ]
 }

--- a/test/rules.json
+++ b/test/rules.json
@@ -1367,7 +1367,7 @@
         "keep": true,
         "attributes": {
           "_dd.appsec.trace.string": {
-            "value": "Gott ist tot"
+            "value": "Lorem ipsum sit amet"
           },
           "_dd.appsec.trace.integer": {
             "value": 662607015

--- a/test/rules.json
+++ b/test/rules.json
@@ -214,6 +214,54 @@
       ]
     },
     {
+      "id": "test-marshalling",
+      "name": "Test ddwaf_object marshalling",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies"
+              }
+            ],
+            "list": [
+              "marshalling"
+            ]
+          },
+          "operator": "phrase_match"
+        }
+      ],
+      "output": {
+        "event": false,
+        "keep": true,
+        "attributes": {
+          "_dd.appsec.trace.string": {
+            "value": "It was a bright cold day in April, and the clocks were striking thirteen."
+          },
+          "_dd.appsec.trace.integer": {
+            "value": 662607015
+          },
+          "_dd.appsec.trace.negative_integer": {
+            "value": -662607015
+          },
+          "_dd.appsec.trace.float": {
+            "value": 2.71828
+          },
+          "_dd.appsec.trace.negative_float": {
+            "value": -3.14159
+          },
+          "_dd.appsec.trace.bool": {
+            "value": true
+          }
+        }
+      },
+      "on_match": []
+    },
+    {
       "id": "long_rule",
       "name": "long rule that shouldn't be truncated",
       "tags": {
@@ -1339,54 +1387,6 @@
       "transformers": [
         "lowercase"
       ]
-    },
-    {
-      "id": "test-marshalling",
-      "name": "Test ddwaf_object marshalling",
-      "tags": {
-        "type": "security_scanner",
-        "category": "attack_attempt"
-      },
-      "conditions": [
-        {
-          "parameters": {
-            "inputs": [
-              {
-                "address": "server.request.headers.no_cookies"
-              }
-            ],
-            "list": [
-              "marshalling"
-            ]
-          },
-          "operator": "phrase_match"
-        }
-      ],
-      "output": {
-        "event": false,
-        "keep": true,
-        "attributes": {
-          "_dd.appsec.trace.string": {
-            "value": "Lorem ipsum sit amet"
-          },
-          "_dd.appsec.trace.integer": {
-            "value": 662607015
-          },
-          "_dd.appsec.trace.negative_integer": {
-            "value": -662607015
-          },
-          "_dd.appsec.trace.float": {
-            "value": 2.71828
-          },
-          "_dd.appsec.trace.negative_float": {
-            "value": -3.14159
-          },
-          "_dd.appsec.trace.bool": {
-            "value": true
-          }
-        }
-      },
-      "on_match": []
     }
   ]
 }


### PR DESCRIPTION
### What does this PR do?

Add support for all ddwaf_object types in `from_ddwaf_object`

### Motivation

Cover all the possible object types in ddwaf_object marshalling

### Additional Notes

Fixes #76 