### PR TITLE
fix: drop no-op install script that triggers Yarn build warning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
-      - run: npm ci
+      - run: npm ci --ignore-scripts
       - run: npm run ${{ matrix.run }}
 
   cpp-lint:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,8 +24,9 @@ jobs:
 
   build:
     needs: download-libddwaf
-    uses: Datadog/action-prebuildify/.github/workflows/build.yml@main
+    uses: Datadog/action-prebuildify/.github/workflows/build.yml@BridgeAR/2026-07-22-preserve-artifact-directories
     with:
+      artifact-name: libddwaf
       cache: true
       napi: true
       package-manager: 'npm'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
 
   build:
     needs: download-libddwaf
-    uses: Datadog/action-prebuildify/.github/workflows/build.yml@BridgeAR/2026-07-22-preserve-artifact-directories
+    uses: Datadog/action-prebuildify/.github/workflows/build.yml@main
     with:
       artifact-name: libddwaf
       cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
 
   build:
     needs: download-libddwaf
-    uses: Datadog/action-prebuildify/.github/workflows/build.yml@BridgeAR/2026-07-22-preserve-artifact-directories
+    uses: Datadog/action-prebuildify/.github/workflows/build.yml@main
     with:
       artifact-name: libddwaf
       cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,9 @@ jobs:
 
   build:
     needs: download-libddwaf
-    uses: Datadog/action-prebuildify/.github/workflows/build.yml@main
+    uses: Datadog/action-prebuildify/.github/workflows/build.yml@BridgeAR/2026-07-22-preserve-artifact-directories
     with:
+      artifact-name: libddwaf
       cache: true
       napi: true
       package-manager: 'npm'

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "index.js",
   "libddwaf_version": "1.30.1",
   "scripts": {
-    "install": "exit 0",
     "rebuild": "node-gyp rebuild",
     "postrebuild": "node scripts/postrebuild",
     "lint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "11.0.1",
   "description": "Node.js bindings for libddwaf",
   "main": "index.js",
+  "gypfile": false,
   "libddwaf_version": "1.30.1",
   "scripts": {
     "rebuild": "node-gyp rebuild",

--- a/test/index.js
+++ b/test/index.js
@@ -12,6 +12,19 @@ const processor = require('./processor.json')
 
 const TIMEOUT = 9999e3
 
+describe('package manifest', () => {
+  it('declares no npm build lifecycle scripts (Yarn Berry YN0007)', () => {
+    const scripts = pkg.scripts || {}
+    const hooks = ['preinstall', 'install', 'postinstall']
+    const present = hooks.filter((name) => scripts[name] !== undefined)
+    assert.deepStrictEqual(
+      present,
+      [],
+      'package.json must not declare npm build lifecycle scripts (they trigger Yarn Berry YN0007)'
+    )
+  })
+})
+
 describe('DDWAF', () => {
   it('should return the version', () => {
     const v = DDWAF.version()

--- a/test/index.js
+++ b/test/index.js
@@ -23,6 +23,10 @@ describe('package manifest', () => {
       'package.json must not declare npm build lifecycle scripts (they trigger Yarn Berry YN0007)'
     )
   })
+
+  it('opts out of npm implicit node-gyp rebuilds', () => {
+    assert.strictEqual(pkg.gypfile, false)
+  })
 })
 
 describe('DDWAF', () => {


### PR DESCRIPTION
## Summary

Yarn Berry (Plug'n'Play) prints `YN0007: @datadog/native-appsec must be built` for any dependency that declares an `install`/`preinstall`/`postinstall` script, including the no-op `"install": "exit 0"`. The package ships prebuilt binaries and excludes `binding.gyp` from the published tarball, so a consumer has nothing to build.

The script also suppressed npm's implicit `node-gyp rebuild` in the dev tree. The `static-checks` job ran a bare `npm ci` without the `libddwaf` artifact, so it now installs with `--ignore-scripts`; the build job already uses `action-prebuildify` (`--ignore-scripts`), so prebuilds are unaffected.

A regression test asserts the manifest declares no build lifecycle scripts.

## Test plan

- [ ] CI green (build, static-checks, cpp-lint)
- [ ] `yarn add @datadog/native-appsec` under Yarn Berry no longer prints YN0007

Refs: https://github.com/DataDog/dd-trace-js/issues/5432